### PR TITLE
Don't pass the -m64 flag to CC when building on ARM

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -4,8 +4,10 @@ endif
 
 ifneq ($(findstring i686,$(TARGET)),)
 	CC := $(CC) -m32
-else
+else ifneq ($(findstring x86_64,$(TARGET)),)
 	CC := $(CC) -m64 -fPIC
+else
+	CC := $(CC) -fPIC
 endif
 
 all:


### PR DESCRIPTION
The -m64 flag is not valid on ARM gcc

cc japaric/ruststrap#4
