### PR TITLE
fix for new BytesReader and AsRefReader traits introduced in recent rust...

### DIFF
--- a/src/gz.rs
+++ b/src/gz.rs
@@ -4,7 +4,7 @@
 
 use std::c_str::CString;
 use std::cmp;
-use std::io::{IoResult, IoError};
+use std::io::{BytesReader,IoResult, IoError};
 use std::io;
 use std::os;
 use std::slice::bytes;


### PR DESCRIPTION
Added BytesReader trait after split introduced in rust-dev.
