### PR TITLE
Fix for rust commit 3dcd2157403163789aaf21a9ab3c4d30a7c6494d 'Switch to ...

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use std::io::IoResult;
 
 pub use gz::Builder as GzBuilder;
 pub use gz::Header as GzHeader;
+pub use CompressionLevel::{BestCompression,BestSpeed,NoCompression};
 
 mod crc;
 mod deflate;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -7,6 +7,7 @@ use libc;
 
 use {CompressionLevel, NoCompression};
 use ffi;
+use self::Flavor::{Deflate,Inflate};
 
 pub struct EncoderWriter<W> {
     pub inner: Option<W>,


### PR DESCRIPTION
...purely namespaced enums'
