### PR TITLE
Make `Compression::{new, none, fast, best}` const fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,17 +198,17 @@ impl Compression {
 
     /// No compression is to be performed, this may actually inflate data
     /// slightly when encoding.
-    pub fn none() -> Compression {
+    pub const fn none() -> Compression {
         Compression(0)
     }
 
     /// Optimize for the best speed of encoding.
-    pub fn fast() -> Compression {
+    pub const fn fast() -> Compression {
         Compression(1)
     }
 
     /// Optimize for the size of data being encoded.
-    pub fn best() -> Compression {
+    pub const fn best() -> Compression {
         Compression(9)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ impl Compression {
     ///
     /// The integer here is typically on a scale of 0-9 where 0 means "no
     /// compression" and 9 means "take as long as you'd like".
-    pub fn new(level: u32) -> Compression {
+    pub const fn new(level: u32) -> Compression {
         Compression(level)
     }
 


### PR DESCRIPTION
Hey, I'm not too familiar with the internals of this compression algorithm but this seems to just be a newtype over an integer? It's the only type I can't construct const-ly in a project, so maybe it could be changed, I hope!

(I don't exactly see a MSRV but I'm pretty sure `const fn` with an integer like this is long supported)