### PR TITLE
Use the error message from z_stream.msg for [De]CompressError

### DIFF
--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -374,39 +374,41 @@ mod c_backend {
     pub type AllocSize = libc::size_t;
 }
 
-/// Zlib specific
-#[cfg(any(
-    feature = "zlib-ng-compat",
-    all(feature = "zlib", not(feature = "cloudflare_zlib"))
-))]
+/// Zlib specific - make zlib mimic miniz' API
+#[cfg(feature = "any_zlib")]
 #[allow(bad_style)]
 mod c_backend {
     use libc::{c_char, c_int};
     use std::mem;
 
-    pub use libz_sys::deflate as mz_deflate;
-    pub use libz_sys::deflateEnd as mz_deflateEnd;
-    pub use libz_sys::deflateReset as mz_deflateReset;
-    pub use libz_sys::inflate as mz_inflate;
-    pub use libz_sys::inflateEnd as mz_inflateEnd;
-    pub use libz_sys::z_stream as mz_stream;
-    pub use libz_sys::*;
+    #[cfg(feature = "cloudflare_zlib")]
+    use cloudflare_zlib_sys as libz;
+    #[cfg(not(feature = "cloudflare_zlib"))]
+    use libz_sys as libz;
 
-    pub use libz_sys::Z_BLOCK as MZ_BLOCK;
-    pub use libz_sys::Z_BUF_ERROR as MZ_BUF_ERROR;
-    pub use libz_sys::Z_DATA_ERROR as MZ_DATA_ERROR;
-    pub use libz_sys::Z_DEFAULT_STRATEGY as MZ_DEFAULT_STRATEGY;
-    pub use libz_sys::Z_DEFLATED as MZ_DEFLATED;
-    pub use libz_sys::Z_FINISH as MZ_FINISH;
-    pub use libz_sys::Z_FULL_FLUSH as MZ_FULL_FLUSH;
-    pub use libz_sys::Z_NEED_DICT as MZ_NEED_DICT;
-    pub use libz_sys::Z_NO_FLUSH as MZ_NO_FLUSH;
-    pub use libz_sys::Z_OK as MZ_OK;
-    pub use libz_sys::Z_PARTIAL_FLUSH as MZ_PARTIAL_FLUSH;
-    pub use libz_sys::Z_STREAM_END as MZ_STREAM_END;
-    pub use libz_sys::Z_STREAM_ERROR as MZ_STREAM_ERROR;
-    pub use libz_sys::Z_SYNC_FLUSH as MZ_SYNC_FLUSH;
-    pub type AllocSize = libz_sys::uInt;
+    pub use libz::deflate as mz_deflate;
+    pub use libz::deflateEnd as mz_deflateEnd;
+    pub use libz::deflateReset as mz_deflateReset;
+    pub use libz::inflate as mz_inflate;
+    pub use libz::inflateEnd as mz_inflateEnd;
+    pub use libz::z_stream as mz_stream;
+    pub use libz::*;
+
+    pub use libz::Z_BLOCK as MZ_BLOCK;
+    pub use libz::Z_BUF_ERROR as MZ_BUF_ERROR;
+    pub use libz::Z_DATA_ERROR as MZ_DATA_ERROR;
+    pub use libz::Z_DEFAULT_STRATEGY as MZ_DEFAULT_STRATEGY;
+    pub use libz::Z_DEFLATED as MZ_DEFLATED;
+    pub use libz::Z_FINISH as MZ_FINISH;
+    pub use libz::Z_FULL_FLUSH as MZ_FULL_FLUSH;
+    pub use libz::Z_NEED_DICT as MZ_NEED_DICT;
+    pub use libz::Z_NO_FLUSH as MZ_NO_FLUSH;
+    pub use libz::Z_OK as MZ_OK;
+    pub use libz::Z_PARTIAL_FLUSH as MZ_PARTIAL_FLUSH;
+    pub use libz::Z_STREAM_END as MZ_STREAM_END;
+    pub use libz::Z_STREAM_ERROR as MZ_STREAM_ERROR;
+    pub use libz::Z_SYNC_FLUSH as MZ_SYNC_FLUSH;
+    pub type AllocSize = libz::uInt;
 
     pub const MZ_DEFAULT_WINDOW_BITS: c_int = 15;
 
@@ -420,7 +422,7 @@ mod c_backend {
         mem_level: c_int,
         strategy: c_int,
     ) -> c_int {
-        libz_sys::deflateInit2_(
+        libz::deflateInit2_(
             stream,
             level,
             method,
@@ -432,71 +434,7 @@ mod c_backend {
         )
     }
     pub unsafe extern "C" fn mz_inflateInit2(stream: *mut mz_stream, window_bits: c_int) -> c_int {
-        libz_sys::inflateInit2_(
-            stream,
-            window_bits,
-            ZLIB_VERSION.as_ptr() as *const c_char,
-            mem::size_of::<mz_stream>() as c_int,
-        )
-    }
-}
-
-/// Cloudflare optimized Zlib specific
-#[cfg(all(feature = "cloudflare_zlib", not(feature = "zlib-ng-compat")))]
-#[allow(bad_style)]
-mod c_backend {
-    use libc::{c_char, c_int};
-    use std::mem;
-
-    pub use cloudflare_zlib_sys::deflate as mz_deflate;
-    pub use cloudflare_zlib_sys::deflateEnd as mz_deflateEnd;
-    pub use cloudflare_zlib_sys::deflateReset as mz_deflateReset;
-    pub use cloudflare_zlib_sys::inflate as mz_inflate;
-    pub use cloudflare_zlib_sys::inflateEnd as mz_inflateEnd;
-    pub use cloudflare_zlib_sys::z_stream as mz_stream;
-    pub use cloudflare_zlib_sys::*;
-
-    pub use cloudflare_zlib_sys::Z_BLOCK as MZ_BLOCK;
-    pub use cloudflare_zlib_sys::Z_BUF_ERROR as MZ_BUF_ERROR;
-    pub use cloudflare_zlib_sys::Z_DATA_ERROR as MZ_DATA_ERROR;
-    pub use cloudflare_zlib_sys::Z_DEFAULT_STRATEGY as MZ_DEFAULT_STRATEGY;
-    pub use cloudflare_zlib_sys::Z_DEFLATED as MZ_DEFLATED;
-    pub use cloudflare_zlib_sys::Z_FINISH as MZ_FINISH;
-    pub use cloudflare_zlib_sys::Z_FULL_FLUSH as MZ_FULL_FLUSH;
-    pub use cloudflare_zlib_sys::Z_NEED_DICT as MZ_NEED_DICT;
-    pub use cloudflare_zlib_sys::Z_NO_FLUSH as MZ_NO_FLUSH;
-    pub use cloudflare_zlib_sys::Z_OK as MZ_OK;
-    pub use cloudflare_zlib_sys::Z_PARTIAL_FLUSH as MZ_PARTIAL_FLUSH;
-    pub use cloudflare_zlib_sys::Z_STREAM_END as MZ_STREAM_END;
-    pub use cloudflare_zlib_sys::Z_STREAM_ERROR as MZ_STREAM_ERROR;
-    pub use cloudflare_zlib_sys::Z_SYNC_FLUSH as MZ_SYNC_FLUSH;
-    pub type AllocSize = cloudflare_zlib_sys::uInt;
-
-    pub const MZ_DEFAULT_WINDOW_BITS: c_int = 15;
-
-    const ZLIB_VERSION: &'static str = "1.2.8\0";
-
-    pub unsafe extern "C" fn mz_deflateInit2(
-        stream: *mut mz_stream,
-        level: c_int,
-        method: c_int,
-        window_bits: c_int,
-        mem_level: c_int,
-        strategy: c_int,
-    ) -> c_int {
-        cloudflare_zlib_sys::deflateInit2_(
-            stream,
-            level,
-            method,
-            window_bits,
-            mem_level,
-            strategy,
-            ZLIB_VERSION.as_ptr() as *const c_char,
-            mem::size_of::<mz_stream>() as c_int,
-        )
-    }
-    pub unsafe extern "C" fn mz_inflateInit2(stream: *mut mz_stream, window_bits: c_int) -> c_int {
-        cloudflare_zlib_sys::inflateInit2_(
+        libz::inflateInit2_(
             stream,
             window_bits,
             ZLIB_VERSION.as_ptr() as *const c_char,

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -44,3 +44,9 @@ cfg_if::cfg_if! {
         pub use self::rust::*;
     }
 }
+
+impl std::fmt::Debug for ErrorMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.get().fmt(f)
+    }
+}

--- a/src/ffi/rust.rs
+++ b/src/ffi/rust.rs
@@ -16,6 +16,16 @@ pub const MZ_FINISH: isize = MZFlush::Finish as isize;
 use super::*;
 use crate::mem;
 
+// miniz_oxide doesn't provide any error messages (yet?)
+#[derive(Default)]
+pub struct ErrorMessage;
+
+impl ErrorMessage {
+    pub fn get(&self) -> Option<&str> {
+        None
+    }
+}
+
 fn format_from_bool(zlib_header: bool) -> DataFormat {
     if zlib_header {
         DataFormat::Zlib
@@ -73,7 +83,7 @@ impl InflateBackend for Inflate {
             },
             Err(status) => match status {
                 MZError::Buf => Ok(Status::BufError),
-                _ => mem::decompress_failed(None),
+                _ => mem::decompress_failed(ErrorMessage),
             },
         }
     }
@@ -144,11 +154,11 @@ impl DeflateBackend for Deflate {
             Ok(status) => match status {
                 MZStatus::Ok => Ok(Status::Ok),
                 MZStatus::StreamEnd => Ok(Status::StreamEnd),
-                MZStatus::NeedDict => mem::compress_failed(None),
+                MZStatus::NeedDict => mem::compress_failed(ErrorMessage),
             },
             Err(status) => match status {
                 MZError::Buf => Ok(Status::BufError),
-                _ => mem::compress_failed(None),
+                _ => mem::compress_failed(ErrorMessage),
             },
         }
     }

--- a/src/ffi/rust.rs
+++ b/src/ffi/rust.rs
@@ -73,7 +73,7 @@ impl InflateBackend for Inflate {
             },
             Err(status) => match status {
                 MZError::Buf => Ok(Status::BufError),
-                _ => mem::decompress_failed(),
+                _ => mem::decompress_failed(None),
             },
         }
     }
@@ -144,11 +144,11 @@ impl DeflateBackend for Deflate {
             Ok(status) => match status {
                 MZStatus::Ok => Ok(Status::Ok),
                 MZStatus::StreamEnd => Ok(Status::StreamEnd),
-                MZStatus::NeedDict => Err(CompressError(())),
+                MZStatus::NeedDict => mem::compress_failed(None),
             },
             Err(status) => match status {
                 MZError::Buf => Ok(Status::BufError),
-                _ => Err(CompressError(())),
+                _ => mem::compress_failed(None),
             },
         }
     }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -771,4 +771,18 @@ mod tests {
 
         assert_eq!(&decoded[..decoder.total_out() as usize], string);
     }
+
+    #[cfg(feature = "any_zlib")]
+    #[test]
+    fn test_error_message() {
+        let mut decoder = Decompress::new(false);
+        let mut decoded = [0; 128];
+        let garbage = b"xbvxzi";
+
+        let err = decoder
+            .decompress(&*garbage, &mut decoded, FlushDecompress::Finish)
+            .unwrap_err();
+
+        assert_eq!(err.message(), Some("invalid stored block lengths"));
+    }
 }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -252,7 +252,7 @@ impl Compress {
     ///
     /// This constructor is only available when the `zlib` feature is used.
     /// Other backends currently do not support gzip headers for Compress.
-    #[cfg(feature = "zlib")]
+    #[cfg(feature = "any_zlib")]
     pub fn new_gzip(level: Compression, window_bits: u8) -> Compress {
         assert!(
             window_bits > 8 && window_bits < 16,
@@ -423,7 +423,7 @@ impl Decompress {
     ///
     /// This constructor is only available when the `zlib` feature is used.
     /// Other backends currently do not support gzip headers for Decompress.
-    #[cfg(feature = "zlib")]
+    #[cfg(feature = "any_zlib")]
     pub fn new_gzip(window_bits: u8) -> Decompress {
         assert!(
             window_bits > 8 && window_bits < 16,
@@ -746,7 +746,7 @@ mod tests {
         assert_eq!(&decoded[..decoder.total_out() as usize], string);
     }
 
-    #[cfg(feature = "zlib")]
+    #[cfg(feature = "any_zlib")]
     #[test]
     fn test_gzip_flate() {
         let string = "hello, hello!".as_bytes();


### PR DESCRIPTION
Not sure if I should put a `#[cfg]` on the `msg` field of the errors for only when zlib is used, since the other backends don't produce errors, or if that would be needlessly complicated.
