### PR TITLE
Minor examlpe tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+examples/*.gz
+.idea

--- a/examples/gzbuilder.rs
+++ b/examples/gzbuilder.rs
@@ -6,14 +6,14 @@ use std::fs::File;
 use std::io;
 use std::io::prelude::*;
 
-// Open file and debug print the contents compressed with gzip
+// Compresses content of a text file into a gzip file
 fn main() {
     sample_builder().unwrap();
 }
 
 // GzBuilder opens a file and writes a sample string using Builder pattern
 fn sample_builder() -> Result<(), io::Error> {
-    let f = File::create("examples/hello_world.gz")?;
+    let f = File::create("examples/hello_world.txt.gz")?;
     let mut gz = GzBuilder::new()
         .filename("hello_world.txt")
         .comment("test file, please delete")

--- a/examples/gzdecoder-bufread.rs
+++ b/examples/gzdecoder-bufread.rs
@@ -1,8 +1,7 @@
 extern crate flate2;
 
-use flate2::bufread::GzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
+use flate2::{bufread, Compression};
 use std::io;
 use std::io::prelude::*;
 
@@ -17,7 +16,7 @@ fn main() {
 // Uncompresses a Gz Encoded vector of bytes and returns a string or error
 // Here &[u8] implements BufRead
 fn decode_reader(bytes: Vec<u8>) -> io::Result<String> {
-    let mut gz = GzDecoder::new(&bytes[..]);
+    let mut gz = bufread::GzDecoder::new(&bytes[..]);
     let mut s = String::new();
     gz.read_to_string(&mut s)?;
     Ok(s)

--- a/examples/gzdecoder-read.rs
+++ b/examples/gzdecoder-read.rs
@@ -1,8 +1,7 @@
 extern crate flate2;
 
-use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
+use flate2::{read, Compression};
 use std::io;
 use std::io::prelude::*;
 
@@ -17,7 +16,7 @@ fn main() {
 // Uncompresses a Gz Encoded vector of bytes and returns a string or error
 // Here &[u8] implements Read
 fn decode_reader(bytes: Vec<u8>) -> io::Result<String> {
-    let mut gz = GzDecoder::new(&bytes[..]);
+    let mut gz = read::GzDecoder::new(&bytes[..]);
     let mut s = String::new();
     gz.read_to_string(&mut s)?;
     Ok(s)


### PR DESCRIPTION
* generates hello_world.txt.gz file - fixes #235
* highlights the difference between gzdecoder-bufread and -read examples
* update gitignore to ignore examlpe *.gz files and IDE files