### PR TITLE
Make Clippy happier, minor cleanups

### DIFF
--- a/src/bufreader.rs
+++ b/src/bufreader.rs
@@ -42,7 +42,7 @@ impl<R: Read> BufReader<R> {
 
     pub fn with_buf(buf: Vec<u8>, inner: R) -> BufReader<R> {
         BufReader {
-            inner: inner,
+            inner,
             buf: buf.into_boxed_slice(),
             pos: 0,
             cap: 0,

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -23,6 +23,12 @@ pub struct CrcReader<R> {
     crc: Crc,
 }
 
+impl Default for Crc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Crc {
     /// Create a new CRC.
     pub fn new() -> Crc {

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -117,6 +117,12 @@ pub struct GzBuilder {
     mtime: u32,
 }
 
+impl Default for GzBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl GzBuilder {
     /// Create a new blank builder with no header by default.
     pub fn new() -> GzBuilder {
@@ -204,28 +210,19 @@ impl GzBuilder {
         } = self;
         let mut flg = 0;
         let mut header = vec![0u8; 10];
-        match extra {
-            Some(v) => {
-                flg |= FEXTRA;
-                header.push((v.len() >> 0) as u8);
-                header.push((v.len() >> 8) as u8);
-                header.extend(v);
-            }
-            None => {}
+        if let Some(v) = extra {
+            flg |= FEXTRA;
+            header.push((v.len() >> 0) as u8);
+            header.push((v.len() >> 8) as u8);
+            header.extend(v);
         }
-        match filename {
-            Some(filename) => {
-                flg |= FNAME;
-                header.extend(filename.as_bytes_with_nul().iter().map(|x| *x));
-            }
-            None => {}
+        if let Some(filename) = filename {
+            flg |= FNAME;
+            header.extend(filename.as_bytes_with_nul().iter().map(|x| *x));
         }
-        match comment {
-            Some(comment) => {
-                flg |= FCOMMENT;
-                header.extend(comment.as_bytes_with_nul().iter().map(|x| *x));
-            }
-            None => {}
+        if let Some(comment) = comment {
+            flg |= FCOMMENT;
+            header.extend(comment.as_bytes_with_nul().iter().map(|x| *x));
         }
         header[0] = 0x1f;
         header[1] = 0x8b;
@@ -248,7 +245,7 @@ impl GzBuilder {
         // default this value to 255. I'm not sure that if we "correctly" set
         // this it'd do anything anyway...
         header[9] = operating_system.unwrap_or(255);
-        return header;
+        header
     }
 }
 

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -43,7 +43,7 @@ pub struct GzEncoder<R> {
 }
 
 pub fn gz_encoder<R: Read>(inner: bufread::GzEncoder<BufReader<R>>) -> GzEncoder<R> {
-    GzEncoder { inner: inner }
+    GzEncoder { inner }
 }
 
 impl<R: Read> GzEncoder<R> {

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -283,7 +283,7 @@ impl Compress {
         let stream = &mut *self.inner.inner.stream_wrapper;
         stream.msg = std::ptr::null_mut();
         let rc = unsafe {
-            assert!(dictionary.len() < ffi::uInt::max_value() as usize);
+            assert!(dictionary.len() < ffi::uInt::MAX as usize);
             ffi::deflateSetDictionary(stream, dictionary.as_ptr(), dictionary.len() as ffi::uInt)
         };
 
@@ -367,7 +367,7 @@ impl Compress {
                 self.compress(input, out, flush)
             };
             output.set_len((self.total_out() - before) as usize + len);
-            return ret;
+            ret
         }
     }
 }
@@ -508,7 +508,7 @@ impl Decompress {
                 self.decompress(input, out, flush)
             };
             output.set_len((self.total_out() - before) as usize + len);
-            return ret;
+            ret
         }
     }
 
@@ -518,7 +518,7 @@ impl Decompress {
         let stream = &mut *self.inner.inner.stream_wrapper;
         stream.msg = std::ptr::null_mut();
         let rc = unsafe {
-            assert!(dictionary.len() < ffi::uInt::max_value() as usize);
+            assert!(dictionary.len() < ffi::uInt::MAX as usize);
             ffi::inflateSetDictionary(stream, dictionary.as_ptr(), dictionary.len() as ffi::uInt)
         };
 

--- a/src/zio.rs
+++ b/src/zio.rs
@@ -143,7 +143,7 @@ where
             // then we need to keep asking for more data because if we
             // return that 0 bytes of data have been read then it will
             // be interpreted as EOF.
-            Ok(Status::Ok) | Ok(Status::BufError) if read == 0 && !eof && dst.len() > 0 => continue,
+            Ok(Status::Ok) | Ok(Status::BufError) if read == 0 && !eof && !dst.is_empty() => continue,
             Ok(Status::Ok) | Ok(Status::BufError) | Ok(Status::StreamEnd) => return Ok(read),
 
             Err(..) => {
@@ -216,13 +216,9 @@ impl<W: Write, D: Ops> Writer<W, D> {
             let before_in = self.data.total_in();
             let ret = self.data.run_vec(buf, &mut self.buf, D::Flush::none());
             let written = (self.data.total_in() - before_in) as usize;
+            let is_stream_end = matches!(ret, Ok(Status::StreamEnd));
 
-            let is_stream_end = match ret {
-                Ok(Status::StreamEnd) => true,
-                _ => false,
-            };
-
-            if buf.len() > 0 && written == 0 && ret.is_ok() && !is_stream_end {
+            if !buf.is_empty() && written == 0 && ret.is_ok() && !is_stream_end {
                 continue;
             }
             return match ret {
@@ -240,7 +236,7 @@ impl<W: Write, D: Ops> Writer<W, D> {
     fn dump(&mut self) -> io::Result<()> {
         // TODO: should manage this buffer not with `drain` but probably more of
         // a deque-like strategy.
-        while self.buf.len() > 0 {
+        while !self.buf.is_empty() {
             let n = self.obj.as_mut().unwrap().write(&self.buf)?;
             if n == 0 {
                 return Err(io::ErrorKind::WriteZero.into());

--- a/src/zio.rs
+++ b/src/zio.rs
@@ -143,7 +143,9 @@ where
             // then we need to keep asking for more data because if we
             // return that 0 bytes of data have been read then it will
             // be interpreted as EOF.
-            Ok(Status::Ok) | Ok(Status::BufError) if read == 0 && !eof && !dst.is_empty() => continue,
+            Ok(Status::Ok) | Ok(Status::BufError) if read == 0 && !eof && !dst.is_empty() => {
+                continue
+            }
             Ok(Status::Ok) | Ok(Status::BufError) | Ok(Status::StreamEnd) => return Ok(read),
 
             Err(..) => {


### PR DESCRIPTION
I ran `cargo clippy` and addressed some issues it raised, while leaving other issues for another time. Hopefully this will make this code a bit easier for newcomers to read.

Biggest changes:
* `foo.len() > 0` ➡ `!foo.is_empty()`
* `return x;` ➡ `x`
* `{ foo: foo }` ➡ `{ foo }`
* adding a few `Default` trait implementations
* some `match` statement cleanup

Also, fixed two `ffi::uInt::max_value()` ➡ `ffi::uInt::MAX` due to deprecation.

Biggest TODOs (please give feedback if they should be fixed too):
* Clippy has complained about many `foo >> 0` -- which is a noop that might confuse (?)
* some other corner cases that I don't know enough about