### PR TITLE
remove libc from default features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,39 +29,39 @@ jobs:
             os: windows-latest
             rust: stable-x86_64-gnu
     steps:
-      - uses: actions/checkout@master
-      - name: Install Rust (rustup)
-        run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-        shell: bash
-      - run: cargo build
-      - run: rustdoc --test README.md -L target/debug/deps --extern flate2=target/debug/libflate2.rlib --edition=2018
-      - run: cargo test
-      - run: cargo test --features zlib
-      - run: cargo test --features miniz
-      - run: cargo test --features zlib --no-default-features
-      - run: cargo test --features zlib-ng-compat --no-default-features
-      - run: cargo test --features cloudflare_zlib --no-default-features
-        if: matrix.build != 'mingw'
-      - run: cargo test --features miniz --no-default-features
-      - run: cargo test --features tokio
+    - uses: actions/checkout@master
+    - name: Install Rust (rustup)
+      run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+      shell: bash
+    - run: cargo build
+    - run: rustdoc --test README.md -L target/debug/deps --extern flate2=target/debug/libflate2.rlib --edition=2018
+    - run: cargo test
+    - run: cargo test --features zlib
+    - run: cargo test --features miniz
+    - run: cargo test --features zlib --no-default-features
+    - run: cargo test --features zlib-ng-compat --no-default-features
+    - run: cargo test --features cloudflare_zlib --no-default-features
+      if: matrix.build != 'mingw'
+    - run: cargo test --features miniz --no-default-features
+    - run: cargo test --features tokio
 
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Install Rust
-        run: rustup update stable && rustup default stable && rustup component add rustfmt
-      - run: cargo fmt -- --check
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update stable && rustup default stable && rustup component add rustfmt
+    - run: cargo fmt -- --check
 
   systest:
     name: Systest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Install Rust
-        run: rustup update stable && rustup default stable
-      - run: cargo run --manifest-path systest/Cargo.toml
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update stable && rustup default stable
+    - run: cargo run --manifest-path systest/Cargo.toml
 
   wasm:
     name: WebAssembly
@@ -70,10 +70,10 @@ jobs:
       matrix:
         target: [wasm32-unknown-unknown, wasm32-wasi]
     steps:
-      - uses: actions/checkout@master
-      - name: Install Rust
-        run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
-      - run: cargo build --target ${{ matrix.target }}
+    - uses: actions/checkout@master
+    - name: Install Rust
+      run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
+    - run: cargo build --target ${{ matrix.target }}
 
   publish_docs:
     name: Publish Documentation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,39 +29,39 @@ jobs:
             os: windows-latest
             rust: stable-x86_64-gnu
     steps:
-    - uses: actions/checkout@master
-    - name: Install Rust (rustup)
-      run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-      shell: bash
-    - run: cargo build
-    - run: rustdoc --test README.md -L target/debug/deps --extern flate2=target/debug/libflate2.rlib --edition=2018
-    - run: cargo test
-    - run: cargo test --features zlib
-    - run: cargo test --features miniz-sys
-    - run: cargo test --features zlib --no-default-features
-    - run: cargo test --features zlib-ng-compat --no-default-features
-    - run: cargo test --features cloudflare_zlib --no-default-features
-      if: matrix.build != 'mingw'
-    - run: cargo test --features miniz-sys --no-default-features
-    - run: cargo test --features tokio
+      - uses: actions/checkout@master
+      - name: Install Rust (rustup)
+        run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
+        shell: bash
+      - run: cargo build
+      - run: rustdoc --test README.md -L target/debug/deps --extern flate2=target/debug/libflate2.rlib --edition=2018
+      - run: cargo test
+      - run: cargo test --features zlib
+      - run: cargo test --features miniz
+      - run: cargo test --features zlib --no-default-features
+      - run: cargo test --features zlib-ng-compat --no-default-features
+      - run: cargo test --features cloudflare_zlib --no-default-features
+        if: matrix.build != 'mingw'
+      - run: cargo test --features miniz --no-default-features
+      - run: cargo test --features tokio
 
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add rustfmt
-    - run: cargo fmt -- --check
+      - uses: actions/checkout@master
+      - name: Install Rust
+        run: rustup update stable && rustup default stable && rustup component add rustfmt
+      - run: cargo fmt -- --check
 
   systest:
     name: Systest
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Install Rust
-      run: rustup update stable && rustup default stable
-    - run: cargo run --manifest-path systest/Cargo.toml
+      - uses: actions/checkout@master
+      - name: Install Rust
+        run: rustup update stable && rustup default stable
+      - run: cargo run --manifest-path systest/Cargo.toml
 
   wasm:
     name: WebAssembly
@@ -70,10 +70,10 @@ jobs:
       matrix:
         target: [wasm32-unknown-unknown, wasm32-wasi]
     steps:
-    - uses: actions/checkout@master
-    - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
-    - run: cargo build --target ${{ matrix.target }}
+      - uses: actions/checkout@master
+      - name: Install Rust
+        run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }}
 
   publish_docs:
     name: Publish Documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ zlib, gzip, and raw deflate streams.
 members = ['systest']
 
 [dependencies]
-libc = "0.2.65"
+libc = { version = "0.2.65", optional = true }
 cfg-if = "1.0.0"
 miniz-sys = { path = "miniz-sys", version = "0.1.11", optional = true }
 libz-sys = { version = "1.1.0", optional = true, default-features = false }
@@ -43,9 +43,10 @@ futures = "0.1"
 
 [features]
 default = ["rust_backend"]
-any_zlib = [] # note: this is not a real user-facing feature
+any_zlib = ["libc"] # note: this is not a real user-facing feature
 zlib = ["any_zlib", "libz-sys"]
 zlib-ng-compat = ["zlib", "libz-sys/zlib-ng"]
 cloudflare_zlib = ["any_zlib", "cloudflare-zlib-sys"]
+miniz = ["libc", "miniz-sys"]
 rust_backend = ["miniz_oxide"]
 tokio = ["tokio-io", "futures"]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ documentation](https://crates.io/crates/cloudflare-zlib-sys). Note that
 uses another version of zlib/libz.
 
 For compatibility with previous versions of `flate2`, the C version of `miniz.c`
-is still available, using the feature `miniz-sys`.
+is still available, using the feature `miniz`.
 
 # License
 


### PR DESCRIPTION
This also required adding an alias for the miniz-sys feature which includes libc, and this is a breaking change for users of the miniz-sys feature: they need to use `miniz` instead or add the `libc` feature.

I am unaware of a way to make this a non-breaking change, and still remove libc from the default.

Another option would be to include libc in the default feature, but not in an explicit rust backend. That would avoid breaking users of miniz-sys that include the default feature, but it would still break users who use it without the default.

This addresses issue #274 