### PR TITLE
Fix build in `wasm{32,64}-unknown-unknown` with `zlib` feature

### DIFF
--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -7,7 +7,10 @@ use std::marker;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
-pub use libc::{c_int, c_uint, c_void, size_t};
+pub use std::os::raw::{c_int, c_uint, c_void};
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+pub use libc::size_t;
 
 use super::*;
 use crate::mem::{self, FlushDecompress, Status};
@@ -378,8 +381,8 @@ mod c_backend {
 #[cfg(feature = "any_zlib")]
 #[allow(bad_style)]
 mod c_backend {
-    use libc::{c_char, c_int};
     use std::mem;
+    use std::os::raw::{c_char, c_int};
 
     #[cfg(feature = "cloudflare_zlib")]
     use cloudflare_zlib_sys as libz;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -313,7 +313,7 @@ impl Compress {
     /// ensures that the function will succeed on the first call.
     #[cfg(feature = "any_zlib")]
     pub fn set_level(&mut self, level: Compression) -> Result<(), CompressError> {
-        use libc::c_int;
+        use std::os::raw::c_int;
         let stream = &mut *self.inner.inner.stream_wrapper;
         stream.msg = std::ptr::null_mut();
 


### PR DESCRIPTION
```
error[E0432]: unresolved import `libc::c_int`
   --> src/mem.rs:316:13
    |
316 |         use libc::c_int;
    |             ^^^^^^^^^^^ no `c_int` in the root

error[E0432]: unresolved imports `libc::c_int`, `libc::c_uint`, `libc::c_void`, `libc::size_t`
  --> src/ffi/c.rs:10:16
   |
10 | pub use libc::{c_int, c_uint, c_void, size_t};
   |                ^^^^^  ^^^^^^  ^^^^^^  ^^^^^^ no `size_t` in the root
   |                |      |       |
   |                |      |       no `c_void` in the root
   |                |      no `c_uint` in the root
   |                no `c_int` in the root

error[E0432]: unresolved imports `libc::c_char`, `libc::c_int`
   --> src/ffi/c.rs:381:16
    |
381 |     use libc::{c_char, c_int};
    |                ^^^^^^  ^^^^^ no `c_int` in the root
    |                |
    |                no `c_char` in the root
```