### PR TITLE
Add support for native zlib-ng via libz-ng-sys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,8 @@ jobs:
     - run: cargo test --features zlib --no-default-features
     - run: cargo test --features zlib-ng-compat --no-default-features
       if: matrix.build != 'mingw'
+    - run: cargo test --features zlib-ng --no-default-features
+      if: matrix.build != 'mingw'
     - run: cargo test --features cloudflare_zlib --no-default-features
       if: matrix.build != 'mingw'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
-version = "1.0.23"
+version = "1.0.24"
 edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -18,7 +18,8 @@ and raw deflate streams.
 
 [dependencies]
 libc = "0.2.65"
-libz-sys = { version = "1.1.0", optional = true, default-features = false }
+libz-sys = { version = "1.1.8", optional = true, default-features = false }
+libz-ng-sys = { version = "1.1.8", optional = true }
 cloudflare-zlib-sys = { version = "0.3.0", optional = true }
 miniz_oxide = { version = "0.5.0", optional = true, default-features = false }
 crc32fast = "1.2.0"
@@ -35,6 +36,7 @@ default = ["rust_backend"]
 any_zlib = [] # note: this is not a real user-facing feature
 zlib = ["any_zlib", "libz-sys"]
 zlib-ng-compat = ["zlib", "libz-sys/zlib-ng"]
+zlib-ng = ["any_zlib", "libz-ng-sys"]
 cloudflare_zlib = ["any_zlib", "cloudflare-zlib-sys"]
 rust_backend = ["miniz_oxide"]
 miniz-sys = ["rust_backend"] # For backwards compatibility

--- a/README.md
+++ b/README.md
@@ -52,8 +52,19 @@ fn main() {
 
 ## Backends
 
-The default `miniz_oxide` backend has the advantage of being pure Rust, but if
-you're already using zlib with another C library, for example, you can use that
+The default `miniz_oxide` backend has the advantage of being pure Rust. If you
+want maximum performance, you can use the zlib-ng C library:
+
+```toml
+[dependencies]
+flate2 = { version = "1.0.17", features = ["zlib-ng"], default-features = false }
+```
+
+Note that the `"zlib-ng"` feature works even if some other part of your crate
+graph depends on zlib.
+
+However, if you're already using another C or Rust library that depends on
+zlib, and you want to avoid including both zlib and zlib-ng, you can use that
 for Rust code as well:
 
 ```toml
@@ -61,19 +72,20 @@ for Rust code as well:
 flate2 = { version = "1.0.17", features = ["zlib"], default-features = false }
 ```
 
-This supports either the high-performance zlib-ng backend (in zlib-compat mode)
-or the use of a shared system zlib library. To explicitly opt into the fast
-zlib-ng backend, use:
+Or, if you have C or Rust code that depends on zlib and you want to use zlib-ng
+via libz-sys in zlib-compat mode, use:
 
 ```toml
 [dependencies]
 flate2 = { version = "1.0.17", features = ["zlib-ng-compat"], default-features = false }
 ```
 
-Note that if any crate in your dependency graph explicitly requests stock zlib,
-or uses libz-sys directly without `default-features = false`, you'll get stock
-zlib rather than zlib-ng. See [the libz-sys
+Note that when using the `"zlib-ng-compat"` feature, if any crate in your
+dependency graph explicitly requests stock zlib, or uses libz-sys directly
+without `default-features = false`, you'll get stock zlib rather than zlib-ng.
+See [the libz-sys
 README](https://github.com/rust-lang/libz-sys/blob/main/README.md) for details.
+To avoid that, use the `"zlib-ng"` feature instead.
 
 For compatibility with previous versions of `flate2`, the cloudflare optimized
 version of zlib is available, via the `cloudflare_zlib` feature. It's not as

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -352,9 +352,13 @@ mod c_backend {
     use libc::{c_char, c_int};
     use std::mem;
 
-    #[cfg(feature = "cloudflare_zlib")]
+    #[cfg(feature = "zlib-ng")]
+    use libz_ng_sys as libz;
+
+    #[cfg(all(not(feature = "zlib-ng"), feature = "cloudflare_zlib"))]
     use cloudflare_zlib_sys as libz;
-    #[cfg(not(feature = "cloudflare_zlib"))]
+
+    #[cfg(all(not(feature = "cloudflare_zlib"), not(feature = "zlib-ng")))]
     use libz_sys as libz;
 
     pub use libz::deflate as mz_deflate;
@@ -383,6 +387,9 @@ mod c_backend {
 
     pub const MZ_DEFAULT_WINDOW_BITS: c_int = 15;
 
+    #[cfg(feature = "zlib-ng")]
+    const ZLIB_VERSION: &'static str = "2.1.0.devel\0";
+    #[cfg(not(feature = "zlib-ng"))]
     const ZLIB_VERSION: &'static str = "1.2.8\0";
 
     pub unsafe extern "C" fn mz_deflateInit2(


### PR DESCRIPTION
Unlike the zlib-ng-compat support, this does not conflict with any crate
using zlib-ng
