### PR TITLE
Fix CI by disabling zlib-ng-compat on mingw

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
     - run: cargo test --features miniz-sys
     - run: cargo test --features zlib --no-default-features
     - run: cargo test --features zlib-ng-compat --no-default-features
+      if: matrix.build != 'mingw'
     - run: cargo test --features cloudflare_zlib --no-default-features
       if: matrix.build != 'mingw'
     - run: cargo test --features miniz-sys --no-default-features


### PR DESCRIPTION
mingw in CI seems to trigger a segfault; I can't reproduce that segfault
outside of a CI environment. Disable this particular feature on mingw to
make the rest of CI usable.
