### PR TITLE
Recommend MultiGzDecoder over GzDecoder in docs

### DIFF
--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -172,8 +172,8 @@ impl<R: BufRead + Write> Write for GzEncoder<R> {
 /// This structure exposes a [`BufRead`] interface, reading compressed data
 /// from the underlying reader, and emitting uncompressed data.
 ///
-/// After reading a single member of the gzip data this reader will return 
-/// Ok(0) even if there are more bytes available in the underlying reader. 
+/// After reading a single member of the gzip data this reader will return
+/// Ok(0) even if there are more bytes available in the underlying reader.
 /// If you need the following bytes, call `into_inner()` after Ok(0) to
 /// recover the underlying reader.
 ///

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -167,8 +167,7 @@ impl<R: BufRead + Write> Write for GzEncoder<R> {
     }
 }
 
-/// A decoder for a single member of a gzip file. Prefer [MultiGzDecoder] for
-/// most uses.
+/// A decoder for a gzip file with a single member.
 ///
 /// This structure consumes a [`BufRead`] interface, reading compressed data
 /// from the underlying reader, and emitting uncompressed data.
@@ -397,11 +396,12 @@ impl<R: BufRead + Write> Write for GzDecoder<R> {
     }
 }
 
-/// A gzip streaming decoder that decodes a complete [gzip file].
+/// A gzip streaming decoder that decodes a [gzip file] with multiple members.
 ///
 /// A gzip file consists of a series of "members" concatenated one after another.
 /// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
-/// the first member. MultiGzDecoder is preferable in most cases.
+/// the first member. Learn more
+/// [in the introduction](https://docs.rs/flate2/*/flate2/#About-multi-member-Gzip-files).
 ///
 /// This structure exposes a [`BufRead`] interface that will consume all gzip members
 /// from the underlying reader and emit uncompressed data.

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -167,11 +167,22 @@ impl<R: BufRead + Write> Write for GzEncoder<R> {
     }
 }
 
-/// A decoder for a gzip file with a single member.
+/// A decoder for the first member of a [gzip file].
 ///
-/// This structure consumes a [`BufRead`] interface, reading compressed data
+/// This structure exposes a [`BufRead`] interface, reading compressed data
 /// from the underlying reader, and emitting uncompressed data.
 ///
+/// After reading the first member of a gzip file (which is often, but not
+/// always, the only member), this reader will return Ok(0) even if there
+/// are more bytes available in the underlying reader. If you want to be sure
+/// not to drop bytes on the floor, call `into_inner()` after Ok(0) to
+/// recover the underlying reader.
+///
+/// To handle gzip files that may have multiple members, see [`MultiGzDecoder`]
+/// or read more
+/// [in the introduction](../index.html#about-multi-member-gzip-files).
+///
+/// [gzip file]: https://www.rfc-editor.org/rfc/rfc1952#page-5
 /// [`BufRead`]: https://doc.rust-lang.org/std/io/trait.BufRead.html
 ///
 /// # Examples
@@ -396,15 +407,17 @@ impl<R: BufRead + Write> Write for GzDecoder<R> {
     }
 }
 
-/// A gzip streaming decoder that decodes a [gzip file] with multiple members.
+/// A gzip streaming decoder that decodes a [gzip file] that may have multiple members.
 ///
-/// A gzip file consists of a series of "members" concatenated one after another.
-/// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
-/// the first member. Learn more
-/// [in the introduction](https://docs.rs/flate2/*/flate2/#About-multi-member-Gzip-files).
+/// This structure exposes a [`BufRead`] interface that will consume compressed
+/// data from the underlying reader and emit uncompressed data.
 ///
-/// This structure exposes a [`BufRead`] interface that will consume all gzip members
-/// from the underlying reader and emit uncompressed data.
+/// A gzip file consists of a series of *members* concatenated one after another.
+/// MultiGzDecoder decodes all members of a file and returns Ok(0) once the
+/// underlying reader does.
+///
+/// To handle members seperately, see [GzDecoder] or read more
+/// [in the introduction](../index.html#about-multi-member-gzip-files).
 ///
 /// [gzip file]: https://www.rfc-editor.org/rfc/rfc1952#page-5
 /// [`BufRead`]: https://doc.rust-lang.org/std/io/trait.BufRead.html

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -167,11 +167,11 @@ impl<R: BufRead + Write> Write for GzEncoder<R> {
     }
 }
 
-/// A gzip streaming decoder
+/// A decoder for a single member of a gzip file. Prefer [MultiGzDecoder] for
+/// most uses.
 ///
 /// This structure consumes a [`BufRead`] interface, reading compressed data
 /// from the underlying reader, and emitting uncompressed data.
-/// Use [`MultiGzDecoder`] if your file has multiple streams.
 ///
 /// [`BufRead`]: https://doc.rust-lang.org/std/io/trait.BufRead.html
 ///
@@ -397,20 +397,16 @@ impl<R: BufRead + Write> Write for GzDecoder<R> {
     }
 }
 
-/// A gzip streaming decoder that decodes all members of a multistream
+/// A gzip streaming decoder that decodes a full [gzip file].
 ///
-/// A gzip member consists of a header, compressed data and a trailer. The [gzip
-/// specification](https://tools.ietf.org/html/rfc1952), however, allows multiple
-/// gzip members to be joined in a single stream. `MultiGzDecoder` will
-/// decode all consecutive members while [`GzDecoder`] will only decompress
-/// the first gzip member. The multistream format is commonly used in
-/// bioinformatics, for example when using the BGZF compressed data. It's also useful
-/// to compress large amounts of data in parallel where each thread produces one stream
-/// for a chunk of input data.
+/// A gzip file consists of a series of "members" concatenated one after another.
+/// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
+/// the first one member. MultiGzDecoder is preferable in most cases.
 ///
 /// This structure exposes a [`BufRead`] interface that will consume all gzip members
 /// from the underlying reader and emit uncompressed data.
 ///
+/// [gzip file]: https://www.rfc-editor.org/rfc/rfc1952#page-5
 /// [`BufRead`]: https://doc.rust-lang.org/std/io/trait.BufRead.html
 ///
 /// # Examples

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -167,15 +167,14 @@ impl<R: BufRead + Write> Write for GzEncoder<R> {
     }
 }
 
-/// A decoder for the first member of a [gzip file].
+/// A decoder for a single member of a [gzip file].
 ///
 /// This structure exposes a [`BufRead`] interface, reading compressed data
 /// from the underlying reader, and emitting uncompressed data.
 ///
-/// After reading the first member of a gzip file (which is often, but not
-/// always, the only member), this reader will return Ok(0) even if there
-/// are more bytes available in the underlying reader. If you want to be sure
-/// not to drop bytes on the floor, call `into_inner()` after Ok(0) to
+/// After reading a single member of the gzip data this reader will return 
+/// Ok(0) even if there are more bytes available in the underlying reader. 
+/// If you need the following bytes, call `into_inner()` after Ok(0) to
 /// recover the underlying reader.
 ///
 /// To handle gzip files that may have multiple members, see [`MultiGzDecoder`]
@@ -413,8 +412,8 @@ impl<R: BufRead + Write> Write for GzDecoder<R> {
 /// data from the underlying reader and emit uncompressed data.
 ///
 /// A gzip file consists of a series of *members* concatenated one after another.
-/// MultiGzDecoder decodes all members of a file and returns Ok(0) once the
-/// underlying reader does.
+/// MultiGzDecoder decodes all members from the data and only returns Ok(0) when the
+/// underlying reader does. For a file, this reads to the end of the file.
 ///
 /// To handle members seperately, see [GzDecoder] or read more
 /// [in the introduction](../index.html#about-multi-member-gzip-files).

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -397,11 +397,11 @@ impl<R: BufRead + Write> Write for GzDecoder<R> {
     }
 }
 
-/// A gzip streaming decoder that decodes a full [gzip file].
+/// A gzip streaming decoder that decodes a complete [gzip file].
 ///
 /// A gzip file consists of a series of "members" concatenated one after another.
 /// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
-/// the first one member. MultiGzDecoder is preferable in most cases.
+/// the first member. MultiGzDecoder is preferable in most cases.
 ///
 /// This structure exposes a [`BufRead`] interface that will consume all gzip members
 /// from the underlying reader and emit uncompressed data.

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -95,11 +95,11 @@ impl<R: Read + Write> Write for GzEncoder<R> {
 /// This structure exposes a [`Read`] interface that will consume compressed
 /// data from the underlying reader and emit uncompressed data.
 ///
-/// After reading the first member of a gzip file (which is often, but not
-/// always, the only member), this reader will return Ok(0) even if there
-/// are more bytes available in the underlying reader. If you want to be sure
-/// not to drop bytes on the floor, call `into_inner()` after Ok(0) to
-/// recover the underlying reader.
+/// After reading a single member of the gzip data this reader will return
+/// Ok(0) even if there are more bytes available in the underlying reader.
+/// `GzDecoder` may have read additional bytes past the end of the gzip data.
+/// If you need the following bytes, wrap the `Reader` in a `std::io::BufReader` 
+/// and use `bufread::GzDecoder` instead.
 ///
 /// To handle gzip files that may have multiple members, see [`MultiGzDecoder`]
 /// or read more

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -90,13 +90,22 @@ impl<R: Read + Write> Write for GzEncoder<R> {
     }
 }
 
-/// A decoder for a gzip file with a single member.
+/// A decoder for the first member of a [gzip file].
 ///
 /// This structure exposes a [`Read`] interface that will consume compressed
 /// data from the underlying reader and emit uncompressed data.
 ///
-/// This decoder only handles gzipped data with a single stream.
-/// Use [`MultiGzDecoder`] for gzipped data with multiple streams.
+/// After reading the first member of a gzip file (which is often, but not
+/// always, the only member), this reader will return Ok(0) even if there
+/// are more bytes available in the underlying reader. If you want to be sure
+/// not to drop bytes on the floor, call `into_inner()` after Ok(0) to
+/// recover the underlying reader.
+///
+/// To handle gzip files that may have multiple members, see [`MultiGzDecoder`]
+/// or read more
+/// [in the introduction](../index.html#about-multi-member-gzip-files).
+///
+/// [gzip file]: https://www.rfc-editor.org/rfc/rfc1952#page-5
 ///
 /// # Examples
 ///
@@ -180,15 +189,17 @@ impl<R: Read + Write> Write for GzDecoder<R> {
     }
 }
 
-/// A gzip streaming decoder that decodes a [gzip file] with multiple members.
+/// A gzip streaming decoder that decodes a [gzip file] that may have multiple members.
 ///
-/// A gzip file consists of a series of "members" concatenated one after another.
-/// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
-/// the first member. Learn more
-/// [in the introduction](https://docs.rs/flate2/*/flate2/#About-multi-member-Gzip-files).
+/// This structure exposes a [`Read`] interface that will consume compressed
+/// data from the underlying reader and emit uncompressed data.
 ///
-/// This structure exposes a [`Read`] interface that will consume all gzip members
-/// from the underlying reader and emit uncompressed data.
+/// A gzip file consists of a series of *members* concatenated one after another.
+/// MultiGzDecoder decodes all members of a file and returns Ok(0) once the
+/// underlying reader does.
+///
+/// To handle members seperately, see [GzDecoder] or read more
+/// [in the introduction](../index.html#about-multi-member-gzip-files).
 ///
 /// [gzip file]: https://www.rfc-editor.org/rfc/rfc1952#page-5
 ///

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -90,11 +90,13 @@ impl<R: Read + Write> Write for GzEncoder<R> {
     }
 }
 
-/// A decoder for a single member of a gzip file. Prefer [MultiGzDecoder] for
-/// most uses.
+/// A decoder for a gzip file with a single member.
 ///
 /// This structure exposes a [`Read`] interface that will consume compressed
 /// data from the underlying reader and emit uncompressed data.
+///
+/// This decoder only handles gzipped data with a single stream.
+/// Use [`MultiGzDecoder`] for gzipped data with multiple streams.
 ///
 /// # Examples
 ///
@@ -178,11 +180,12 @@ impl<R: Read + Write> Write for GzDecoder<R> {
     }
 }
 
-/// A gzip streaming decoder that decodes a full [gzip file].
+/// A gzip streaming decoder that decodes a [gzip file] with multiple members.
 ///
 /// A gzip file consists of a series of "members" concatenated one after another.
 /// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
-/// the first member. MultiGzDecoder is preferable in most cases.
+/// the first member. Learn more
+/// [in the introduction](https://docs.rs/flate2/*/flate2/#About-multi-member-Gzip-files).
 ///
 /// This structure exposes a [`Read`] interface that will consume all gzip members
 /// from the underlying reader and emit uncompressed data.

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -90,13 +90,11 @@ impl<R: Read + Write> Write for GzEncoder<R> {
     }
 }
 
-/// A gzip streaming decoder
+/// A decoder for a single member of a gzip file. Prefer [MultiGzDecoder] for
+/// most uses.
 ///
 /// This structure exposes a [`Read`] interface that will consume compressed
 /// data from the underlying reader and emit uncompressed data.
-/// Use [`MultiGzDecoder`] if your file has multiple streams.
-///
-/// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
 ///
 /// # Examples
 ///
@@ -180,21 +178,16 @@ impl<R: Read + Write> Write for GzDecoder<R> {
     }
 }
 
-/// A gzip streaming decoder that decodes all members of a multistream
+/// A gzip streaming decoder that decodes a full [gzip file].
 ///
-/// A gzip member consists of a header, compressed data and a trailer. The [gzip
-/// specification](https://tools.ietf.org/html/rfc1952), however, allows multiple
-/// gzip members to be joined in a single stream.  `MultiGzDecoder` will
-/// decode all consecutive members while [`GzDecoder`] will only decompress the
-/// first gzip member. The multistream format is commonly used in bioinformatics,
-/// for example when using the BGZF compressed data. It's also useful
-/// to compress large amounts of data in parallel where each thread produces one stream
-/// for a chunk of input data.
+/// A gzip file consists of a series of "members" concatenated one after another.
+/// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
+/// the first one member. MultiGzDecoder is preferable in most cases.
 ///
 /// This structure exposes a [`Read`] interface that will consume all gzip members
 /// from the underlying reader and emit uncompressed data.
 ///
-/// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
+/// [gzip file]: https://www.rfc-editor.org/rfc/rfc1952#page-5
 ///
 /// # Examples
 ///

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -98,7 +98,7 @@ impl<R: Read + Write> Write for GzEncoder<R> {
 /// After reading a single member of the gzip data this reader will return
 /// Ok(0) even if there are more bytes available in the underlying reader.
 /// `GzDecoder` may have read additional bytes past the end of the gzip data.
-/// If you need the following bytes, wrap the `Reader` in a `std::io::BufReader` 
+/// If you need the following bytes, wrap the `Reader` in a `std::io::BufReader`
 /// and use `bufread::GzDecoder` instead.
 ///
 /// To handle gzip files that may have multiple members, see [`MultiGzDecoder`]

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -182,7 +182,7 @@ impl<R: Read + Write> Write for GzDecoder<R> {
 ///
 /// A gzip file consists of a series of "members" concatenated one after another.
 /// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
-/// the first one member. MultiGzDecoder is preferable in most cases.
+/// the first member. MultiGzDecoder is preferable in most cases.
 ///
 /// This structure exposes a [`Read`] interface that will consume all gzip members
 /// from the underlying reader and emit uncompressed data.

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -171,8 +171,8 @@ impl<W: Write> Drop for GzEncoder<W> {
 /// This structure exposes a [`Write`] interface, receiving compressed data and
 /// writing uncompressed data to the underlying writer.
 ///
-/// After decoding a single member of the gzip data this writer will return the number of bytes up to 
-/// to the end of the gzip member and subsequent writes will return Ok(0) allowing the caller to 
+/// After decoding a single member of the gzip data this writer will return the number of bytes up to
+/// to the end of the gzip member and subsequent writes will return Ok(0) allowing the caller to
 /// handle any data following the gzip member.
 ///
 /// To handle gzip files that may have multiple members, see [`MultiGzDecoder`]

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -166,13 +166,14 @@ impl<W: Write> Drop for GzEncoder<W> {
     }
 }
 
-/// A decoder for the first member of a [gzip file].
+/// A decoder for a single member of a [gzip file].
 ///
 /// This structure exposes a [`Write`] interface, receiving compressed data and
 /// writing uncompressed data to the underlying writer.
 ///
-/// After decoding the first member of a gzip file, this writer will return XXX
-/// to all subsequent writes.
+/// After decoding a single member of the gzip data this writer will return the number of bytes up to 
+/// to the end of the gzip member and subsequent writes will return Ok(0) allowing the caller to 
+/// handle any data following the gzip member.
 ///
 /// To handle gzip files that may have multiple members, see [`MultiGzDecoder`]
 /// or read more

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -166,11 +166,11 @@ impl<W: Write> Drop for GzEncoder<W> {
     }
 }
 
-/// A gzip streaming decoder
+/// A decoder for a single member of a gzip file. Prefer [MultiGzDecoder] for
+/// most uses.
 ///
 /// This structure exposes a [`Write`] interface that will emit uncompressed data
 /// to the underlying writer `W`.
-/// Use [`MultiGzDecoder`] if your file has multiple streams.
 ///
 /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 ///
@@ -373,17 +373,16 @@ impl<W: Read + Write> Read for GzDecoder<W> {
     }
 }
 
-/// A gzip streaming decoder that decodes all members of a multistream
+/// A gzip streaming decoder that decodes a full [gzip file].
 ///
-/// A gzip member consists of a header, compressed data and a trailer. The [gzip
-/// specification](https://tools.ietf.org/html/rfc1952), however, allows multiple
-/// gzip members to be joined in a single stream. `MultiGzDecoder` will
-/// decode all consecutive members while `GzDecoder` will only decompress
-/// the first gzip member. The multistream format is commonly used in
-/// bioinformatics, for example when using the BGZF compressed data.
+/// A gzip file consists of a series of "members" concatenated one after another.
+/// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
+/// the first one member. MultiGzDecoder is preferable in most cases.
 ///
 /// This structure exposes a [`Write`] interface that will consume all gzip members
 /// from the written buffers and write uncompressed data to the writer.
+///
+/// [gzip file]: https://www.rfc-editor.org/rfc/rfc1952#page-5
 #[derive(Debug)]
 pub struct MultiGzDecoder<W: Write> {
     inner: GzDecoder<W>,

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -377,7 +377,7 @@ impl<W: Read + Write> Read for GzDecoder<W> {
 ///
 /// A gzip file consists of a series of "members" concatenated one after another.
 /// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
-/// the first one member. MultiGzDecoder is preferable in most cases.
+/// the first member. MultiGzDecoder is preferable in most cases.
 ///
 /// This structure exposes a [`Write`] interface that will consume all gzip members
 /// from the written buffers and write uncompressed data to the writer.

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -166,14 +166,19 @@ impl<W: Write> Drop for GzEncoder<W> {
     }
 }
 
-/// A decoder for a gzip file with a single member.
+/// A decoder for the first member of a [gzip file].
 ///
-/// This structure exposes a [`Write`] interface that will emit uncompressed data
-/// to the underlying writer `W`.
+/// This structure exposes a [`Write`] interface, receiving compressed data and
+/// writing uncompressed data to the underlying writer.
 ///
-/// This decoder only handles gzipped data with a single stream.
-/// Use [`MultiGzDecoder`] for gzipped data with multiple streams.
+/// After decoding the first member of a gzip file, this writer will return XXX
+/// to all subsequent writes.
 ///
+/// To handle gzip files that may have multiple members, see [`MultiGzDecoder`]
+/// or read more
+/// [in the introduction](../index.html#about-multi-member-gzip-files).
+///
+/// [gzip file]: https://www.rfc-editor.org/rfc/rfc1952#page-5
 /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 ///
 /// # Examples
@@ -377,13 +382,15 @@ impl<W: Read + Write> Read for GzDecoder<W> {
 
 /// A gzip streaming decoder that decodes a [gzip file] with multiple members.
 ///
-/// A gzip file consists of a series of "members" concatenated one after another.
-/// `MultiGzDecoder` decodes all members of a file, while [GzDecoder] will only decode
-/// the first member. Learn more
-/// [in the introduction](https://docs.rs/flate2/*/flate2/#About-multi-member-Gzip-files).
+/// This structure exposes a [`Write`] interface that will consume compressed data and
+/// write uncompressed data to the underlying writer.
 ///
-/// This structure exposes a [`Write`] interface that will consume all gzip members
-/// from the written buffers and write uncompressed data to the writer.
+/// A gzip file consists of a series of *members* concatenated one after another.
+/// `MultiGzDecoder` decodes all members of a file and writes them to the
+/// underlying writer one after another.
+///
+/// To handle members separately, see [GzDecoder] or read more
+/// [in the introduction](../index.html#about-multi-member-gzip-files).
 ///
 /// [gzip file]: https://www.rfc-editor.org/rfc/rfc1952#page-5
 #[derive(Debug)]

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -166,11 +166,13 @@ impl<W: Write> Drop for GzEncoder<W> {
     }
 }
 
-/// A decoder for a single member of a gzip file. Prefer [MultiGzDecoder] for
-/// most uses.
+/// A decoder for a gzip file with a single member.
 ///
 /// This structure exposes a [`Write`] interface that will emit uncompressed data
 /// to the underlying writer `W`.
+///
+/// This decoder only handles gzipped data with a single stream.
+/// Use [`MultiGzDecoder`] for gzipped data with multiple streams.
 ///
 /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 ///
@@ -373,11 +375,12 @@ impl<W: Read + Write> Read for GzDecoder<W> {
     }
 }
 
-/// A gzip streaming decoder that decodes a full [gzip file].
+/// A gzip streaming decoder that decodes a [gzip file] with multiple members.
 ///
 /// A gzip file consists of a series of "members" concatenated one after another.
-/// MultiGzDecoder decodes all members of a file, while [GzDecoder] will only decode
-/// the first member. MultiGzDecoder is preferable in most cases.
+/// `MultiGzDecoder` decodes all members of a file, while [GzDecoder] will only decode
+/// the first member. Learn more
+/// [in the introduction](https://docs.rs/flate2/*/flate2/#About-multi-member-Gzip-files).
 ///
 /// This structure exposes a [`Write`] interface that will consume all gzip members
 /// from the written buffers and write uncompressed data to the writer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,13 +73,16 @@
 //! If these are read with a [`GzDecoder`], only the first member will be consumed and
 //! the rest will silently be left alone, which can be surprising.
 //!
-//! The [`MultiGzDecoder`] on the other hand will decode all *members* of `gzip` file
-//! into one consecutive stream of bytes, which hides the underlying *members* entirely
-//! while failing if the file does not contain solely `gzip` *members*.
+//! The [`MultiGzDecoder`] on the other hand will decode all members of a `gzip` file
+//! into one consecutive stream of bytes, which hides the underlying *members* entirely.
+//! If a file contains contains non-gzip data after the gzip data, MultiGzDecoder will
+//! emit an error after decoding the gzip data. This behavior matches the `gzip`,
+//! `gunzip`, and `zcat` command line tools.
 //!
-//! It's worth noting that major browser like Chrome, Firefox as well as tool like `curl`
-//! will only decode the first member of a `gzip` encoded reply, so what's right to do
-//! truly depends on the context, as well the expected input of the library or application.
+//! Chrome and Firefox appear to implement behavior like `GzDecoder`, ignoring data
+//! after the first member. `curl` appears to implement behavior somewhat like
+//! `GzDecoder`, only decoding the first member, but emitting an error if there is
+//! data after the first member, whether or not it is gzip data.
 //!
 //! [`read`]: read/index.html
 //! [`bufread`]: bufread/index.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@
 //! While most `gzip` files one encounters will have a single *member* that can be read
 //! with the [`GzDecoder`], there may be some files which have multiple members.
 //!
-//! A [`GzDecoder`] will only read the first member of gzip data, which may unexpectedly 
-//! provide partial results when a multi-member gzip file is encountered. `GzDecoder` is appropriate 
+//! A [`GzDecoder`] will only read the first member of gzip data, which may unexpectedly
+//! provide partial results when a multi-member gzip file is encountered. `GzDecoder` is appropriate
 //! for data that is designed to be read as single members from a multi-member file. `bufread::GzDecoder`
 //! and `write::GzDecoder` also allow non-gzip data following gzip data to be handled.
 //!
@@ -80,11 +80,6 @@
 //! If a file contains contains non-gzip data after the gzip data, MultiGzDecoder will
 //! emit an error after decoding the gzip data. This behavior matches the `gzip`,
 //! `gunzip`, and `zcat` command line tools.
-//!
-//! Chrome and Firefox appear to implement behavior like `GzDecoder`, ignoring data
-//! after the first member. `curl` appears to implement behavior somewhat like
-//! `GzDecoder`, only decoding the first member, but emitting an error if there is
-//! data after the first member, whether or not it is gzip data.
 //!
 //! [`read`]: read/index.html
 //! [`bufread`]: bufread/index.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,12 +65,30 @@
 //! `Write` trait if `T: Write`. That is, the "dual trait" is forwarded directly
 //! to the underlying object if available.
 //!
+//! # About multi-member Gzip files
+//!
+//! While most `gzip` files one encounters will have a single *member* that can be read
+//! with the [`GzDecoder`], there may be some files which have multiple members.
+//!
+//! If these are read with a [`GzDecoder`], only the first member will be consumed and
+//! the rest will silently be left alone, which can be surprising.
+//!
+//! The [`MultiGzDecoder`] on the other hand will decode all *members* of `gzip` file
+//! into one consecutive stream of bytes, which hides the underlying *members* entirely
+//! while failing if the file does not contain solely `gzip` *members*.
+//!
+//! It's worth noting that major browser like Chrome, Firefox as well as tool like `curl`
+//! will only decode the first member of a `gzip` encoded reply, so what's right to do
+//! truly depends on the context, as well the expected input of the library or application.
+//!
 //! [`read`]: read/index.html
 //! [`bufread`]: bufread/index.html
 //! [`write`]: write/index.html
 //! [read]: https://doc.rust-lang.org/std/io/trait.Read.html
 //! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
 //! [bufread]: https://doc.rust-lang.org/std/io/trait.BufRead.html
+//! [`GzDecoder`]: read/struct.GzDecoder.html
+//! [`MultiGzDecoder`]: read/struct.MultiGzDecoder.html
 #![doc(html_root_url = "https://docs.rs/flate2/0.2")]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,10 @@
 //! While most `gzip` files one encounters will have a single *member* that can be read
 //! with the [`GzDecoder`], there may be some files which have multiple members.
 //!
-//! If these are read with a [`GzDecoder`], only the first member will be consumed and
-//! the rest will silently be left alone, which can be surprising.
+//! A [`GzDecoder`] will only read the first member of gzip data, which may unexpectedly 
+//! provide partial results when a multi-member gzip file is encountered. `GzDecoder` is appropriate 
+//! for data that is designed to be read as single members from a multi-member file. `bufread::GzDecoder`
+//! and `write::GzDecoder` also allow non-gzip data following gzip data to be handled.
 //!
 //! The [`MultiGzDecoder`] on the other hand will decode all members of a `gzip` file
 //! into one consecutive stream of bytes, which hides the underlying *members* entirely.


### PR DESCRIPTION
Part of #178.

I removed the text that says "the specification, however, allows ..." and the comment about bioinformatics because they make it sound like MultiGzDecoder is a rare thing that you should only enable if you need it, but it's actually the correct choice for almost all cases since it implements what the RFC considers a "gzip file."