### PR TITLE
Fixed overflow bug in crc combine

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -63,7 +63,7 @@ impl Crc {
 
     /// Combine the CRC with the CRC for the subsequent block of bytes.
     pub fn combine(&mut self, additional_crc: &Crc) {
-        self.amt += additional_crc.amt;
+        self.amt = self.amt.wrapping_add(additional_crc.amt);
         self.hasher.combine(&additional_crc.hasher);
     }
 }


### PR DESCRIPTION
The combine function for the CRC hash can cause integer overflow if the amt variable is close to u32::MAX. To fix this I changed the regular add to wrapping add, the same way the update function works. 