### PR TITLE
Mention MSRV policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Supported formats:
 flate2 = "1.0"
 ```
 
+## MSRV (Minimum Supported Rust Version) Policy
+
+This crate supports the current stable and the last stable for the latest version.
+For example, if the current stable is 1.64, this crate supports 1.64 and 1.63.
+Older stables may work, but we don't guarantee these will continue to work.
+
 ## Compression
 
 ```rust


### PR DESCRIPTION
This declares our MSRV policy on README. It's based on Alex's this comment: https://github.com/rust-lang/flate2-rs/issues/207#issuecomment-521771662
Since the maintainership has been changed, someone may want to change the policy. I'm open to any suggestions, e.g. wider window, or a fixed MSRV.


Signed-off-by: Yuki Okushi <jtitor@2k36.org>
