### PR TITLE
Bump miniz-oxide to prevent assertion failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ and raw deflate streams.
 libz-sys = { version = "1.1.8", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.8", optional = true }
 cloudflare-zlib-sys = { version = "0.3.0", optional = true }
-miniz_oxide = { version = "0.6.0", optional = true, default-features = false, features = ["with-alloc"] }
+miniz_oxide = { version = "0.7.1", optional = true, default-features = false, features = ["with-alloc"] }
 crc32fast = "1.2.0"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-miniz_oxide = { version = "0.6.0", default-features = false, features = ["with-alloc"] }
+miniz_oxide = { version = "0.7.1", default-features = false, features = ["with-alloc"] }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
miniz-oxide is crashing with 'assertion failed: out_pos > source_pos', that was fixed after release 0.6.4. 