### PR TITLE
Fix a typo in doc for write::GzDecoder

### DIFF
--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -169,7 +169,7 @@ impl<W: Write> Drop for GzEncoder<W> {
 
 /// A gzip streaming decoder
 ///
-/// This structure exposes a [`Write`] interface that will emit compressed data
+/// This structure exposes a [`Write`] interface that will emit uncompressed data
 /// to the underlying writer `W`.
 ///
 /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html


### PR DESCRIPTION
Hi there,

While reading the documents of flate2-rs, I found a typo in `write::GzDecoder`. It should be emitting uncompressed data if I understand it correctly, so here's the pull request to fix it. Thanks.

Regards,
Philip