### PR TITLE
Export all headers from MultiGzDecoder

### DIFF
--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -237,9 +237,9 @@ impl<R: Read> MultiGzDecoder<R> {
 }
 
 impl<R> MultiGzDecoder<R> {
-    /// Returns the current header associated with this stream, if it's valid.
-    pub fn header(&self) -> Option<&GzHeader> {
-        self.inner.header()
+    /// Returns the headers processed so far
+    pub fn headers(&self) -> Vec<&GzHeader> {
+        self.inner.headers()
     }
 
     /// Acquires a reference to the underlying reader.


### PR DESCRIPTION
Hi and thanks for your crate.

This patch replaces the `header` interface with a `headers` interface in MultiGzDecoder as it's otherwise very hard if not impossible to inspect all the gzip "members" that are processed.

It has no impact on GzDecoder itself except for an extra empty vector added to it.

I've kept the diff as compact as possible.