### PR TITLE
Fix Read encoder examples

### DIFF
--- a/src/deflate/read.rs
+++ b/src/deflate/read.rs
@@ -25,11 +25,11 @@ use crate::bufreader::BufReader;
 /// #
 /// // Return a vector containing the Deflate compressed version of hello world
 /// fn deflateencoder_read_hello_world() -> io::Result<Vec<u8>> {
-///    let mut ret_vec = [0;100];
+///    let mut ret_vec = Vec::new();
 ///    let c = b"hello world";
 ///    let mut deflater = DeflateEncoder::new(&c[..], Compression::fast());
-///    let count = deflater.read(&mut ret_vec)?;
-///    Ok(ret_vec[0..count].to_vec())
+///    let count = deflater.read_to_end(&mut ret_vec)?;
+///    Ok(ret_vec)
 /// }
 /// ```
 #[derive(Debug)]

--- a/src/deflate/read.rs
+++ b/src/deflate/read.rs
@@ -28,7 +28,7 @@ use crate::bufreader::BufReader;
 ///    let mut ret_vec = Vec::new();
 ///    let c = b"hello world";
 ///    let mut deflater = DeflateEncoder::new(&c[..], Compression::fast());
-///    let count = deflater.read_to_end(&mut ret_vec)?;
+///    deflater.read_to_end(&mut ret_vec)?;
 ///    Ok(ret_vec)
 /// }
 /// ```

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -25,11 +25,11 @@ use crate::Compression;
 /// // Return a vector containing the GZ compressed version of hello world
 ///
 /// fn gzencode_hello_world() -> io::Result<Vec<u8>> {
-///     let mut ret_vec = [0;100];
+///     let mut ret_vec = Vec::new();
 ///     let bytestring = b"hello world";
 ///     let mut gz = GzEncoder::new(&bytestring[..], Compression::fast());
-///     let count = gz.read(&mut ret_vec)?;
-///     Ok(ret_vec[0..count].to_vec())
+///     let count = gz.read_to_end(&mut ret_vec)?;
+///     Ok(ret_vec)
 /// }
 /// ```
 #[derive(Debug)]

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -28,7 +28,7 @@ use crate::Compression;
 ///     let mut ret_vec = Vec::new();
 ///     let bytestring = b"hello world";
 ///     let mut gz = GzEncoder::new(&bytestring[..], Compression::fast());
-///     let count = gz.read_to_end(&mut ret_vec)?;
+///     gz.read_to_end(&mut ret_vec)?;
 ///     Ok(ret_vec)
 /// }
 /// ```

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -25,7 +25,7 @@ use crate::bufreader::BufReader;
 /// let f = File::open("examples/hello_world.txt")?;
 /// let mut z = ZlibEncoder::new(f, Compression::fast());
 /// let mut buffer = Vec::new();
-/// let byte_count = z.read_to_end(&mut buffer)?;
+/// z.read_to_end(&mut buffer)?;
 /// # Ok(buffer)
 /// # }
 /// ```

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -24,9 +24,9 @@ use crate::bufreader::BufReader;
 /// # fn open_hello_world() -> std::io::Result<Vec<u8>> {
 /// let f = File::open("examples/hello_world.txt")?;
 /// let mut z = ZlibEncoder::new(f, Compression::fast());
-/// let mut buffer = [0;50];
-/// let byte_count = z.read(&mut buffer)?;
-/// # Ok(buffer[0..byte_count].to_vec())
+/// let mut buffer = Vec::new();
+/// let byte_count = z.read_to_end(&mut buffer)?;
+/// # Ok(buffer)
 /// # }
 /// ```
 #[derive(Debug)]


### PR DESCRIPTION
The examples for the Read encoders previously used the read method to
read data. However, as pointed out in issue 158, this may only read
part of the data. Instead the read_to_end method should be used.

Fixes: #355
