### PR TITLE
Add functionality for custom (de)compress instances

### DIFF
--- a/src/zlib/bufread.rs
+++ b/src/zlib/bufread.rs
@@ -48,12 +48,12 @@ impl<R: BufRead> ZlibEncoder<R> {
         }
     }
 
-    /// Same as `new` but instead of passing a `Compression` instance,
-    /// a `Compress` instance is passed.
-    pub fn new_with_compress(r: R, compress: crate::Compress) -> ZlibEncoder<R> {
+    /// Creates a new encoder with given `compresson` settings which will
+    /// read uncompressed data from the given stream `r` and emit the compressed stream.
+    pub fn new_with_compress(r: R, compression: crate::Compress) -> ZlibEncoder<R> {
         ZlibEncoder {
             obj: r,
-            data: compress,
+            data: compression,
         }
     }
 }

--- a/src/zlib/bufread.rs
+++ b/src/zlib/bufread.rs
@@ -48,9 +48,9 @@ impl<R: BufRead> ZlibEncoder<R> {
         }
     }
 
-    /// Creates a new encoder with given `compresson` settings which will
+    /// Creates a new encoder with the given `compression` settings which will
     /// read uncompressed data from the given stream `r` and emit the compressed stream.
-    pub fn new_with_compress(r: R, compression: crate::Compress) -> ZlibEncoder<R> {
+    pub fn new_with_compress(r: R, compression: Compress) -> ZlibEncoder<R> {
         ZlibEncoder {
             obj: r,
             data: compression,
@@ -176,13 +176,11 @@ impl<R: BufRead> ZlibDecoder<R> {
     }
 
     /// Creates a new decoder which will decompress data read from the given
-    /// stream.
-    ///
-    /// Also takes in a Decompress instance.
-    pub fn new_with_decompress(r: R, decompress: Decompress) -> ZlibDecoder<R> {
+    /// stream, using the given `decompression` settings.
+    pub fn new_with_decompress(r: R, decompression: Decompress) -> ZlibDecoder<R> {
         ZlibDecoder {
             obj: r,
-            data: decompress,
+            data: decompression,
         }
     }
 }

--- a/src/zlib/bufread.rs
+++ b/src/zlib/bufread.rs
@@ -47,6 +47,15 @@ impl<R: BufRead> ZlibEncoder<R> {
             data: Compress::new(level, true),
         }
     }
+
+    /// Same as `new` but instead of passing a `Compression` instance,
+    /// a `Compress` instance is passed.
+    pub fn new_with_compress(r: R, compress: crate::Compress) -> ZlibEncoder<R> {
+        ZlibEncoder {
+            obj: r,
+            data: compress,
+        }
+    }
 }
 
 pub fn reset_encoder_data<R>(zlib: &mut ZlibEncoder<R>) {
@@ -163,6 +172,17 @@ impl<R: BufRead> ZlibDecoder<R> {
         ZlibDecoder {
             obj: r,
             data: Decompress::new(true),
+        }
+    }
+
+    /// Creates a new decoder which will decompress data read from the given
+    /// stream.
+    ///
+    /// Also takes in a Decompress instance.
+    pub fn new_with_decompress(r: R, decompress: Decompress) -> ZlibDecoder<R> {
+        ZlibDecoder {
+            obj: r,
+            data: decompress,
         }
     }
 }

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -44,11 +44,11 @@ impl<R: Read> ZlibEncoder<R> {
         }
     }
 
-    /// Same as `new` but with the ability to add a `Compress` instance rather
-    /// than a `Compression` instance.
-    pub fn new_with_compress(r: R, compress: crate::Compress) -> ZlibEncoder<R> {
+    /// Creates a new encoder with given `compression` settings which will
+    /// read uncompressed data from the given stream `r` and emit the compressed stream.
+    pub fn new_with_compress(r: R, compression: crate::Compress) -> ZlibEncoder<R> {
         ZlibEncoder {
-            inner: bufread::ZlibEncoder::new_with_compress(BufReader::new(r), compress),
+            inner: bufread::ZlibEncoder::new_with_compress(BufReader::new(r), compression),
         }
     }
 }
@@ -169,7 +169,8 @@ impl<R: Read> ZlibDecoder<R> {
         ZlibDecoder::new_with_buf(r, vec![0; 32 * 1024])
     }
 
-    /// Same as `new`, but the intermediate buffer for data is specified.
+    /// Creates a new decoder along with `buf` for intermediate data,
+    /// which will decompress data read from the given stream `r`.
     ///
     /// Note that the specified buffer will only be used up to its current
     /// length. The buffer's capacity will also not grow over time.
@@ -180,26 +181,26 @@ impl<R: Read> ZlibDecoder<R> {
     }
 
     /// Creates a new decoder which will decompress data read from the given
-    /// stream.
-    ///
-    /// Also takes in a custom `Decompress` instance.
-    pub fn new_with_decompress(r: R, decompress: Decompress) -> ZlibDecoder<R> {
-        ZlibDecoder::new_with_decompress_and_buf(r, vec![0; 32 * 1024], decompress)
+    /// stream `r`, along with `decompression` settings
+    pub fn new_with_decompress(r: R, decompression: Decompress) -> ZlibDecoder<R> {
+        ZlibDecoder::new_with_decompress_and_buf(r, vec![0; 32 * 1024], decompression)
     }
 
-    /// Same as `new_with_decompress`, but the intermediate buffer for data is specified.
+    /// Creates a new decoder along with `buf` for intermediate data,
+    /// which will decompress data read from the given stream `r`, along with
+    /// `decompression` settings
     ///
     /// Note that the specified buffer will only be used up to its current
     /// length. The buffer's capacity will also not grow over time.
     pub fn new_with_decompress_and_buf(
         r: R,
         buf: Vec<u8>,
-        decompress: Decompress,
+        decompression: Decompress,
     ) -> ZlibDecoder<R> {
         ZlibDecoder {
             inner: bufread::ZlibDecoder::new_with_decompress(
                 BufReader::with_buf(buf, r),
-                decompress,
+                decompression,
             ),
         }
     }

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -182,7 +182,7 @@ impl<R: Read> ZlibDecoder<R> {
     /// Creates a new decoder which will decompress data read from the given
     /// stream.
     ///
-    /// Also takes in a custom Decompress instance.
+    /// Also takes in a custom `Decompress` instance.
     pub fn new_with_decompress(r: R, decompress: Decompress) -> ZlibDecoder<R> {
         ZlibDecoder::new_with_decompress_and_buf(r, vec![0; 32 * 1024], decompress)
     }

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -44,7 +44,7 @@ impl<R: Read> ZlibEncoder<R> {
         }
     }
 
-    /// Creates a new encoder with given `compression` settings which will
+    /// Creates a new encoder with the given `compression` settings which will
     /// read uncompressed data from the given stream `r` and emit the compressed stream.
     pub fn new_with_compress(r: R, compression: crate::Compress) -> ZlibEncoder<R> {
         ZlibEncoder {
@@ -169,8 +169,8 @@ impl<R: Read> ZlibDecoder<R> {
         ZlibDecoder::new_with_buf(r, vec![0; 32 * 1024])
     }
 
-    /// Creates a new decoder along with `buf` for intermediate data,
-    /// which will decompress data read from the given stream `r`.
+    /// Creates a new decoder which will decompress data read from the given
+    /// stream `r`, using `buf` as backing to speed up reading.
     ///
     /// Note that the specified buffer will only be used up to its current
     /// length. The buffer's capacity will also not grow over time.
@@ -181,14 +181,14 @@ impl<R: Read> ZlibDecoder<R> {
     }
 
     /// Creates a new decoder which will decompress data read from the given
-    /// stream `r`, along with `decompression` settings
+    /// stream `r`, along with `decompression` settings.
     pub fn new_with_decompress(r: R, decompression: Decompress) -> ZlibDecoder<R> {
         ZlibDecoder::new_with_decompress_and_buf(r, vec![0; 32 * 1024], decompression)
     }
 
-    /// Creates a new decoder along with `buf` for intermediate data,
-    /// which will decompress data read from the given stream `r`, along with
-    /// `decompression` settings
+    /// Creates a new decoder which will decompress data read from the given
+    /// stream `r`, using `buf` as backing to speed up reading,
+    /// along with `decompression` settings to configure decoder.
     ///
     /// Note that the specified buffer will only be used up to its current
     /// length. The buffer's capacity will also not grow over time.

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -3,6 +3,7 @@ use std::io::prelude::*;
 
 use super::bufread;
 use crate::bufreader::BufReader;
+use crate::Decompress;
 
 /// A ZLIB encoder, or compressor.
 ///
@@ -40,6 +41,14 @@ impl<R: Read> ZlibEncoder<R> {
     pub fn new(r: R, level: crate::Compression) -> ZlibEncoder<R> {
         ZlibEncoder {
             inner: bufread::ZlibEncoder::new(BufReader::new(r), level),
+        }
+    }
+
+    /// Same as `new` but with the ability to add a `Compress` instance rather
+    /// than a `Compression` instance.
+    pub fn new_with_compress(r: R, compress: crate::Compress) -> ZlibEncoder<R> {
+        ZlibEncoder {
+            inner: bufread::ZlibEncoder::new_with_compress(BufReader::new(r), compress),
         }
     }
 }
@@ -167,6 +176,31 @@ impl<R: Read> ZlibDecoder<R> {
     pub fn new_with_buf(r: R, buf: Vec<u8>) -> ZlibDecoder<R> {
         ZlibDecoder {
             inner: bufread::ZlibDecoder::new(BufReader::with_buf(buf, r)),
+        }
+    }
+
+    /// Creates a new decoder which will decompress data read from the given
+    /// stream.
+    ///
+    /// Also takes in a custom Decompress instance.
+    pub fn new_with_decompress(r: R, decompress: Decompress) -> ZlibDecoder<R> {
+        ZlibDecoder::new_with_decompress_and_buf(r, vec![0; 32 * 1024], decompress)
+    }
+
+    /// Same as `new_with_decompress`, but the intermediate buffer for data is specified.
+    ///
+    /// Note that the specified buffer will only be used up to its current
+    /// length. The buffer's capacity will also not grow over time.
+    pub fn new_with_decompress_and_buf(
+        r: R,
+        buf: Vec<u8>,
+        decompress: Decompress,
+    ) -> ZlibDecoder<R> {
+        ZlibDecoder {
+            inner: bufread::ZlibDecoder::new_with_decompress(
+                BufReader::with_buf(buf, r),
+                decompress,
+            ),
         }
     }
 }

--- a/src/zlib/write.rs
+++ b/src/zlib/write.rs
@@ -46,7 +46,7 @@ impl<W: Write> ZlibEncoder<W> {
 
     /// Creates a new encoder which will write compressed data to the stream
     /// `w` with the given `compression` settings.
-    pub fn new_with_compress(w: W, compression: crate::Compress) -> ZlibEncoder<W> {
+    pub fn new_with_compress(w: W, compression: Compress) -> ZlibEncoder<W> {
         ZlibEncoder {
             inner: zio::Writer::new(w, compression),
         }

--- a/src/zlib/write.rs
+++ b/src/zlib/write.rs
@@ -44,6 +44,14 @@ impl<W: Write> ZlibEncoder<W> {
         }
     }
 
+    /// Same as `new` but with the ability to add a `Compress` instance rather
+    /// than a `Compression` instance.
+    pub fn new_with_compress(w: W, compress: crate::Compress) -> ZlibEncoder<W> {
+        ZlibEncoder {
+            inner: zio::Writer::new(w, compress),
+        }
+    }
+
     /// Acquires a reference to the underlying writer.
     pub fn get_ref(&self) -> &W {
         self.inner.get_ref()
@@ -215,6 +223,13 @@ impl<W: Write> ZlibDecoder<W> {
     pub fn new(w: W) -> ZlibDecoder<W> {
         ZlibDecoder {
             inner: zio::Writer::new(w, Decompress::new(true)),
+        }
+    }
+
+    /// This is like `new` but with a supplied `Decompress` instance.
+    pub fn new_with_decompress(w: W, decomp: Decompress) -> ZlibDecoder<W> {
+        ZlibDecoder {
+            inner: zio::Writer::new(w, decomp),
         }
     }
 

--- a/src/zlib/write.rs
+++ b/src/zlib/write.rs
@@ -44,11 +44,11 @@ impl<W: Write> ZlibEncoder<W> {
         }
     }
 
-    /// Same as `new` but with the ability to add a `Compress` instance rather
-    /// than a `Compression` instance.
-    pub fn new_with_compress(w: W, compress: crate::Compress) -> ZlibEncoder<W> {
+    /// Creates a new encoder which will write compressed data to the stream
+    /// `w` with the given `compression` settings.
+    pub fn new_with_compress(w: W, compression: crate::Compress) -> ZlibEncoder<W> {
         ZlibEncoder {
-            inner: zio::Writer::new(w, compress),
+            inner: zio::Writer::new(w, compression),
         }
     }
 
@@ -226,10 +226,14 @@ impl<W: Write> ZlibDecoder<W> {
         }
     }
 
-    /// This is like `new` but with a supplied `Decompress` instance.
-    pub fn new_with_decompress(w: W, decomp: Decompress) -> ZlibDecoder<W> {
+    /// Creates a new decoder which will write uncompressed data to the stream `w`
+    /// using the given `decompression` settings.
+    ///
+    /// When this decoder is dropped or unwrapped the final pieces of data will
+    /// be flushed.
+    pub fn new_with_decompress(w: W, decompression: Decompress) -> ZlibDecoder<W> {
         ZlibDecoder {
-            inner: zio::Writer::new(w, decomp),
+            inner: zio::Writer::new(w, decompression),
         }
     }
 


### PR DESCRIPTION
Adding these functions make it easier to use custom `Decompress` and `Compress` instances. Sometimes these are needed to change the `window_bits` or `zlib_header`, without these functions its kinda painful to implement it.

added functions:

bufread
- ZlibEncoder::new_with_compress
- ZlibDecoder::new_with_decompress

read
- ZlibEncoder::new_with_compress
- ZlibDecoder::new_with_decompress
- ZlibDecoder::new_with_decompress_and_buf

write
- ZlibEncoder::new_with_compress
- ZlibDecoder::new_with_decompress