### PR TITLE
prepare 1.0.27 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
-version = "1.0.26"
+version = "1.0.27"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This release contains improved documentation and a few API improvements.