### PR TITLE
Use explicit Default for GzHeaderState enum

### DIFF
--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -87,7 +87,7 @@ impl GzHeader {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub enum GzHeaderState {
     Start(u8, [u8; 10]),
     Xlen(Option<Box<Crc>>, u8, [u8; 2]),
@@ -95,8 +95,13 @@ pub enum GzHeaderState {
     Filename(Option<Box<Crc>>),
     Comment(Option<Box<Crc>>),
     Crc(Option<Box<Crc>>, u8, [u8; 2]),
-    #[default]
     Complete,
+}
+
+impl Default for GzHeaderState {
+    fn default() -> Self {
+        Self::Complete
+    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
While the MSRV policy only requires n-2 support, there's no need to increase it for minimal benefit. Using an explicit Default reduces the MSRV from 1.62 to 1.53.

Is there a `rust-lang` policy for adding the `"rust"` MSRV to `Cargo.toml`?