### PR TITLE
Add `continue_with` function to ZlibDecoder that allows refreshing of the stream without resetting the bufreader and fix resetting of ZlibDecoder

### DIFF
--- a/src/zlib/bufread.rs
+++ b/src/zlib/bufread.rs
@@ -215,6 +215,16 @@ impl<R> ZlibDecoder<R> {
         &mut self.obj
     }
 
+    /// Acquires a reference to the underlying `Decompress` instance
+    pub fn get_data(&self) -> &Decompress {
+        &self.data
+    }
+
+    /// Acquires a mutable reference to the underlying `Decompress` instance
+    pub fn get_data_mut(&mut self) -> &mut Decompress {
+        &mut self.data
+    }
+
     /// Consumes this decoder, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.obj

--- a/src/zlib/bufread.rs
+++ b/src/zlib/bufread.rs
@@ -48,9 +48,9 @@ impl<R: BufRead> ZlibEncoder<R> {
         }
     }
 
-    /// Creates a new encoder with given `compresson` settings which will
+    /// Creates a new encoder with the given `compression` settings which will
     /// read uncompressed data from the given stream `r` and emit the compressed stream.
-    pub fn new_with_compress(r: R, compression: crate::Compress) -> ZlibEncoder<R> {
+    pub fn new_with_compress(r: R, compression: Compress) -> ZlibEncoder<R> {
         ZlibEncoder {
             obj: r,
             data: compression,
@@ -176,13 +176,11 @@ impl<R: BufRead> ZlibDecoder<R> {
     }
 
     /// Creates a new decoder which will decompress data read from the given
-    /// stream.
-    ///
-    /// Also takes in a Decompress instance.
-    pub fn new_with_decompress(r: R, decompress: Decompress) -> ZlibDecoder<R> {
+    /// stream, using the given `decompression` settings.
+    pub fn new_with_decompress(r: R, decompression: Decompress) -> ZlibDecoder<R> {
         ZlibDecoder {
             obj: r,
-            data: decompress,
+            data: decompression,
         }
     }
 }

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -222,6 +222,17 @@ impl<R> ZlibDecoder<R> {
         self.inner.get_mut().reset(r)
     }
 
+
+    /// Resets the state of the decoder entirely
+    /// Opposed to `reset`, this function takes into account that there was
+    /// previously a custom Decompress in place
+    /// 
+    /// `zlib_header` should be whatever was used before in `new_with_decompress`
+    pub fn reset_on_custom(&mut self, r: R, zlib_header: bool) -> R {
+        self.inner.get_data_mut().reset(zlib_header);
+        self.inner.get_mut().reset(r)
+    }
+
     /// Resets the stream for another, without wiping the bufreader.
     /// Use this when your 2nd stream is dependant on previous' streams.
     pub fn continue_read(&mut self, r: R) -> R {

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -222,11 +222,10 @@ impl<R> ZlibDecoder<R> {
         self.inner.get_mut().reset(r)
     }
 
-
     /// Resets the state of the decoder entirely
     /// Opposed to `reset`, this function takes into account that there was
     /// previously a custom Decompress in place
-    /// 
+    ///
     /// `zlib_header` should be whatever was used before in `new_with_decompress`
     pub fn reset_on_custom(&mut self, r: R, zlib_header: bool) -> R {
         self.inner.get_data_mut().reset(zlib_header);

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -44,7 +44,7 @@ impl<R: Read> ZlibEncoder<R> {
         }
     }
 
-    /// Creates a new encoder with given `compression` settings which will
+    /// Creates a new encoder with the given `compression` settings which will
     /// read uncompressed data from the given stream `r` and emit the compressed stream.
     pub fn new_with_compress(r: R, compression: crate::Compress) -> ZlibEncoder<R> {
         ZlibEncoder {
@@ -169,8 +169,8 @@ impl<R: Read> ZlibDecoder<R> {
         ZlibDecoder::new_with_buf(r, vec![0; 32 * 1024])
     }
 
-    /// Creates a new decoder along with `buf` for intermediate data,
-    /// which will decompress data read from the given stream `r`.
+    /// Creates a new decoder which will decompress data read from the given
+    /// stream `r`, using `buf` as backing to speed up reading.
     ///
     /// Note that the specified buffer will only be used up to its current
     /// length. The buffer's capacity will also not grow over time.
@@ -181,14 +181,14 @@ impl<R: Read> ZlibDecoder<R> {
     }
 
     /// Creates a new decoder which will decompress data read from the given
-    /// stream `r`, along with `decompression` settings
+    /// stream `r`, along with `decompression` settings.
     pub fn new_with_decompress(r: R, decompression: Decompress) -> ZlibDecoder<R> {
         ZlibDecoder::new_with_decompress_and_buf(r, vec![0; 32 * 1024], decompression)
     }
 
-    /// Creates a new decoder along with `buf` for intermediate data,
-    /// which will decompress data read from the given stream `r`, along with
-    /// `decompression` settings
+    /// Creates a new decoder which will decompress data read from the given
+    /// stream `r`, using `buf` as backing to speed up reading,
+    /// along with `decompression` settings to configure decoder.
     ///
     /// Note that the specified buffer will only be used up to its current
     /// length. The buffer's capacity will also not grow over time.

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -222,6 +222,12 @@ impl<R> ZlibDecoder<R> {
         self.inner.get_mut().reset(r)
     }
 
+    /// Resets the stream for another, without wiping the bufreader.
+    /// Use this when your 2nd stream is dependant on previous' streams.
+    pub fn continue_read(&mut self, r: R) -> R {
+        self.inner.get_mut().reset(r)
+    }
+
     /// Acquires a reference to the underlying stream
     pub fn get_ref(&self) -> &R {
         self.inner.get_ref().get_ref()

--- a/src/zlib/write.rs
+++ b/src/zlib/write.rs
@@ -46,7 +46,7 @@ impl<W: Write> ZlibEncoder<W> {
 
     /// Creates a new encoder which will write compressed data to the stream
     /// `w` with the given `compression` settings.
-    pub fn new_with_compress(w: W, compression: crate::Compress) -> ZlibEncoder<W> {
+    pub fn new_with_compress(w: W, compression: Compress) -> ZlibEncoder<W> {
         ZlibEncoder {
             inner: zio::Writer::new(w, compression),
         }


### PR DESCRIPTION
Examples:
```rust
use flate2::{Decompress, read::ZlibDecoder};
use std::io::prelude::Read;

fn continue_with_example() {
    // Python ZLIB compressed with options: zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -zlib.MAX_WBITS

    // b'{"msgs":[{"msg": "ping"}]}'
    let msg_vec1 = vec![
        170, 86, 202, 45, 78, 47, 86, 178, 138, 174, 6, 49, 148, 172, 20, 148, 10, 50, 243, 210,
        149, 106, 99, 107, 1, 0, 0, 0, 255, 255,
    ];

    // b'{"msgs":[{"msg": "lobby_clear"},{"msg": "lobby_complete"}]}'
    let msg_vec2 = vec![
        170, 198, 144, 201, 201, 79, 74, 170, 140, 79, 206, 73, 77, 44, 82, 170, 213, 65, 23, 206,
        207, 45, 200, 73, 45, 73, 5, 105, 5, 0,
    ];

    let mut decompresser = ZlibDecoder::new_with_decompress(
        &msg_vec1[..],
        Decompress::new_with_window_bits(false, 15),
    );

    let mut msg1 = String::new();
    decompresser.read_to_string(&mut msg1).unwrap();
    println!("{}", msg1);

    decompresser.continue_read(&msg_vec2[..]);

    let mut msg2 = String::new();
    decompresser.read_to_string(&mut msg2).unwrap();
    println!("{}", msg2);
}

fn reset_example() {
    // b'{"msgs":[{"msg": "ping"}]}'
    let msg_vec1 = vec![
        170, 86, 202, 45, 78, 47, 86, 178, 138, 174, 6, 49, 148, 172, 20, 148, 10, 50, 243, 210,
        149, 106, 99, 107, 1, 0, 0, 0, 255, 255,
    ];

    let mut decompresser = ZlibDecoder::new_with_decompress(
        &msg_vec1[..],
        Decompress::new_with_window_bits(false, 15),
    );

    let mut msg1 = String::new();
    decompresser.read_to_string(&mut msg1).unwrap();
    println!("{}", msg1);

    decompresser.reset_on_custom(&msg_vec1[..], false);

    let mut msg2 = String::new();
    decompresser.read_to_string(&mut msg2).unwrap();
    println!("{}", msg2);
}

```

This should help #312 and #276

NOTE: This does not affect read&write ZlibEncoder and write ZlibDecoder. These are yet to be written.