### PR TITLE
prepare next patch-release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
-version = "1.0.27"
+version = "1.0.28"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
A release to incorporate fixes related to uses of uninitialized memory, originally requested [here](https://github.com/rust-lang/flate2-rs/issues/220#issuecomment-1756362420).