### PR TITLE
Fix build for beta and nightly

### DIFF
--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -359,6 +359,7 @@ pub use self::c_backend::*;
 
 /// For backwards compatibility, we provide symbols as `mz_` to mimic the miniz API
 #[allow(bad_style)]
+#[allow(unused_imports)]
 mod c_backend {
     use std::mem;
     use std::os::raw::{c_char, c_int};


### PR DESCRIPTION
Unused import is considered as hard fail for current beta and nightly

```
 % cargo +nightly test --features zlib
   Compiling flate2 v1.0.28 (/Users/jakub/dev/rust/flate2-rs)
error: unused import: `libz::Z_BLOCK as MZ_BLOCK`
   --> src/ffi/c.rs:384:13
    |
384 |     pub use libz::Z_BLOCK as MZ_BLOCK;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:96:24
    |
96  | #![cfg_attr(test, deny(warnings))]
    |                        ^^^^^^^^
    = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`

warning: unused import: `libz::Z_BLOCK as MZ_BLOCK`
   --> src/ffi/c.rs:384:13
    |
384 |     pub use libz::Z_BLOCK as MZ_BLOCK;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: `flate2` (lib) generated 1 warning (run `cargo fix --lib -p flate2` to apply 1 suggestion)
error: could not compile `flate2` (lib test) due to 1 previous error
```