### PR TITLE
Store `StreamWrapper::inner` as a raw pointer

### DIFF
--- a/src/mem.rs
+++ b/src/mem.rs
@@ -265,16 +265,19 @@ impl Compress {
     /// Returns the Adler-32 checksum of the dictionary.
     #[cfg(feature = "any_zlib")]
     pub fn set_dictionary(&mut self, dictionary: &[u8]) -> Result<u32, CompressError> {
-        let stream = &mut *self.inner.inner.stream_wrapper;
-        stream.msg = std::ptr::null_mut();
+        // SAFETY: The field `inner` must always be accessed as a raw pointer,
+        // since it points to a cyclic structure. No copies of `inner` can be
+        // retained for longer than the lifetime of `self.inner.inner.stream_wrapper`.
+        let stream = self.inner.inner.stream_wrapper.inner;
         let rc = unsafe {
+            (*stream).msg = std::ptr::null_mut();
             assert!(dictionary.len() < ffi::uInt::MAX as usize);
             ffi::deflateSetDictionary(stream, dictionary.as_ptr(), dictionary.len() as ffi::uInt)
         };
 
         match rc {
             ffi::MZ_STREAM_ERROR => compress_failed(self.inner.inner.msg()),
-            ffi::MZ_OK => Ok(stream.adler as u32),
+            ffi::MZ_OK => Ok(unsafe { (*stream).adler } as u32),
             c => panic!("unknown return code: {}", c),
         }
     }
@@ -299,9 +302,13 @@ impl Compress {
     #[cfg(feature = "any_zlib")]
     pub fn set_level(&mut self, level: Compression) -> Result<(), CompressError> {
         use std::os::raw::c_int;
-        let stream = &mut *self.inner.inner.stream_wrapper;
-        stream.msg = std::ptr::null_mut();
-
+        // SAFETY: The field `inner` must always be accessed as a raw pointer,
+        // since it points to a cyclic structure. No copies of `inner` can be
+        // retained for longer than the lifetime of `self.inner.inner.stream_wrapper`.
+        let stream = self.inner.inner.stream_wrapper.inner;
+        unsafe {
+            (*stream).msg = std::ptr::null_mut();
+        }
         let rc = unsafe { ffi::deflateParams(stream, level.0 as c_int, ffi::MZ_DEFAULT_STRATEGY) };
 
         match rc {
@@ -476,17 +483,20 @@ impl Decompress {
     /// Specifies the decompression dictionary to use.
     #[cfg(feature = "any_zlib")]
     pub fn set_dictionary(&mut self, dictionary: &[u8]) -> Result<u32, DecompressError> {
-        let stream = &mut *self.inner.inner.stream_wrapper;
-        stream.msg = std::ptr::null_mut();
+        // SAFETY: The field `inner` must always be accessed as a raw pointer,
+        // since it points to a cyclic structure. No copies of `inner` can be
+        // retained for longer than the lifetime of `self.inner.inner.stream_wrapper`.
+        let stream = self.inner.inner.stream_wrapper.inner;
         let rc = unsafe {
+            (*stream).msg = std::ptr::null_mut();
             assert!(dictionary.len() < ffi::uInt::MAX as usize);
             ffi::inflateSetDictionary(stream, dictionary.as_ptr(), dictionary.len() as ffi::uInt)
         };
 
         match rc {
             ffi::MZ_STREAM_ERROR => decompress_failed(self.inner.inner.msg()),
-            ffi::MZ_DATA_ERROR => decompress_need_dict(stream.adler as u32),
-            ffi::MZ_OK => Ok(stream.adler as u32),
+            ffi::MZ_DATA_ERROR => decompress_need_dict(unsafe { (*stream).adler } as u32),
+            ffi::MZ_OK => Ok(unsafe { (*stream).adler } as u32),
             c => panic!("unknown return code: {}", c),
         }
     }


### PR DESCRIPTION
Fixes #392.

Storing and accessing `StreamWrapper` as a raw pointer fixes a tree borrows violation and removes the need for implementations of `Deref` and `DerefMut`.