### PR TITLE
Avoid redudant imports

### DIFF
--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -8,7 +8,7 @@ use std::os::raw::{c_int, c_uint, c_void};
 use std::ptr;
 
 use super::*;
-use crate::mem::{self, FlushDecompress, Status};
+use crate::mem;
 
 #[derive(Default)]
 pub struct ErrorMessage(Option<&'static str>);


### PR DESCRIPTION
`cargo check` of nightly flags it, which is used for testing in `libz-sys`.

Fixes build error here: https://github.com/rust-lang/libz-sys/pull/187 that [look like this](https://github.com/rust-lang/libz-sys/actions/runs/8284565523/job/22670409386?pr=187#step:6:182).