### PR TITLE
add `zlib-rs` support via the `libz-rs-sys` C api for `zlib-rs`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,8 @@ jobs:
       if: matrix.build != 'mingw'
     - run: cargo test --features zlib-ng --no-default-features
       if: matrix.build != 'mingw'
+    - run: cargo test --features zlib-rs --no-default-features
+      if: matrix.build != 'mingw'
     - run: cargo test --features cloudflare_zlib --no-default-features
       if: matrix.build != 'mingw'
     - run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ and raw deflate streams.
 [dependencies]
 libz-sys = { version = "1.1.8", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.8", optional = true }
+libz-rs-sys = { version = "0.1.1", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.0", optional = true }
 miniz_oxide = { version = "0.7.1", optional = true, default-features = false, features = ["with-alloc"] }
 crc32fast = "1.2.0"
@@ -38,6 +39,7 @@ zlib = ["any_zlib", "libz-sys"]
 zlib-default = ["any_zlib", "libz-sys/default"]
 zlib-ng-compat = ["zlib", "libz-sys/zlib-ng"]
 zlib-ng = ["any_zlib", "libz-ng-sys"]
+zlib-rs = ["any_zlib", "libz-rs-sys"]
 cloudflare_zlib = ["any_zlib", "cloudflare-zlib-sys"]
 rust_backend = ["miniz_oxide", "any_impl"]
 miniz-sys = ["rust_backend"] # For backwards compatibility


### PR DESCRIPTION
This PR adds (experimental) support for using flate2 with the zlib-rs backend. The `zlib-rs` crate is a pure-rust implementation of the zlib api that makes use of SIMD to achieve performance close to zlib-ng (currently 5% to 10% slower).

- [ISRG project page](https://www.memorysafety.org/initiative/zlib/)
- [`libz-rs-sys` docs](https://docs.rs/libz-rs-sys/0.1.0/libz_rs_sys/index.html)

For the moment, the libz-rs-sys C api is used for the integration. At some point in the future, zlib-rs will get a more convenient rust api that will require less (hopefully no) unsafe code.

cc @joshtriplett 