### PR TITLE
Add tests to show BufRead can be used after decoding

### DIFF
--- a/src/deflate/bufread.rs
+++ b/src/deflate/bufread.rs
@@ -243,3 +243,50 @@ impl<W: BufRead + Write> Write for DeflateDecoder<W> {
         self.get_mut().flush()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::bufread::DeflateDecoder;
+    use crate::deflate::write;
+    use crate::Compression;
+    use std::io::{Read, Write};
+
+    // DeflateDecoder consumes one deflate archive and then returns 0 for subsequent reads, allowing any
+    // additional data to be consumed by the caller.
+    #[test]
+    fn decode_extra_data() {
+        let expected = "Hello World";
+
+        let compressed = {
+            let mut e = write::DeflateEncoder::new(Vec::new(), Compression::default());
+            e.write(expected.as_ref()).unwrap();
+            let mut b = e.finish().unwrap();
+            b.push(b'x');
+            b
+        };
+
+        let mut output = Vec::new();
+        let mut decoder = DeflateDecoder::new(compressed.as_slice());
+        let decoded_bytes = decoder.read_to_end(&mut output).unwrap();
+        assert_eq!(decoded_bytes, output.len());
+        let actual = std::str::from_utf8(&output).expect("String parsing error");
+        assert_eq!(
+            actual, expected,
+            "after decompression we obtain the original input"
+        );
+
+        output.clear();
+        assert_eq!(
+            decoder.read(&mut output).unwrap(),
+            0,
+            "subsequent read of decoder returns 0, but inner reader can return additional data"
+        );
+        let mut reader = decoder.into_inner();
+        assert_eq!(
+            reader.read_to_end(&mut output).unwrap(),
+            1,
+            "extra data is accessible in underlying buf-read"
+        );
+        assert_eq!(output, b"x");
+    }
+}

--- a/src/zlib/write.rs
+++ b/src/zlib/write.rs
@@ -338,3 +338,43 @@ impl<W: Read + Write> Read for ZlibDecoder<W> {
         self.inner.get_mut().read(buf)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Compression;
+
+    const STR: &str = "Hello World Hello World Hello World Hello World Hello World \
+        Hello World Hello World Hello World Hello World Hello World \
+        Hello World Hello World Hello World Hello World Hello World \
+        Hello World Hello World Hello World Hello World Hello World \
+        Hello World Hello World Hello World Hello World Hello World";
+
+    // ZlibDecoder consumes one zlib archive and then returns 0 for subsequent writes, allowing any
+    // additional data to be consumed by the caller.
+    #[test]
+    fn decode_extra_data() {
+        let compressed = {
+            let mut e = ZlibEncoder::new(Vec::new(), Compression::default());
+            e.write(STR.as_ref()).unwrap();
+            let mut b = e.finish().unwrap();
+            b.push(b'x');
+            b
+        };
+
+        let mut writer = Vec::new();
+        let mut decoder = ZlibDecoder::new(writer);
+        let mut consumed_bytes = 0;
+        loop {
+            let n = decoder.write(&compressed[consumed_bytes..]).unwrap();
+            if n == 0 {
+                break;
+            }
+            consumed_bytes += n;
+        }
+        writer = decoder.finish().unwrap();
+        let actual = String::from_utf8(writer).expect("String parsing error");
+        assert_eq!(actual, STR);
+        assert_eq!(&compressed[consumed_bytes..], b"x");
+    }
+}


### PR DESCRIPTION
Copy the trailing data tests from `gzip::bufread` and `gzip::write` to demonstrate that they also work for `zlib` and `deflate`.

This demonstrates that #401 works with `bufread` decoders.