### PR TITLE
Update actions/checkout in GitHub Actions workflows to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
             os: windows-2022
             rust: stable-x86_64-gnu
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
@@ -58,7 +58,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt -- --check
@@ -70,7 +70,7 @@ jobs:
       matrix:
         target: [wasm32-unknown-unknown, wasm32-wasi]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
     - run: cargo build --target ${{ matrix.target }}


### PR DESCRIPTION
Updates the [`actions/checkout`](https://github.com/actions/checkout) action used in the GitHub Actions workflows to its newest major version.

Still using v3 of `actions/checkout` will generate some warning like in this run: https://github.com/rust-lang/flate2-rs/actions/runs/8845176603

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The PR will get rid of those warnings for `actions/checkout`, because v4 uses Node.js 20.