### PR TITLE
update miniz_oxide dependency to 0.8.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ libz-sys = { version = "1.1.8", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.8", optional = true }
 libz-rs-sys = { version = "0.2.1", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.0", optional = true }
-miniz_oxide = { version = "0.7.1", optional = true, default-features = false, features = ["with-alloc"] }
+miniz_oxide = { version = "0.8.0", optional = true, default-features = false, features = ["with-alloc"] }
 crc32fast = "1.2.0"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-miniz_oxide = { version = "0.7.1", default-features = false, features = ["with-alloc"] }
+miniz_oxide = { version = "0.8.0", default-features = false, features = ["with-alloc"] }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
Version bump is mainly to change from the [adler](https://crates.io/crates/adler) crate to the [adler2](https://crates.io/crates/adler2) fork of it as the original is no longer maintained 

see https://github.com/rustsec/advisory-db/issues/1992

Also bumps minimum rust version a little but it's still way below what flate2 states as it's minimum supported version.