### PR TITLE
Check minimal version of Rust that compiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # I don't really understand the build matrix here...
-        build: [stable, beta, nightly, macos, windows, mingw]
+        build: [stable, beta, nightly, minimal, macos, windows, mingw]
         include:
           - build: stable
             os: ubuntu-latest
@@ -48,11 +47,11 @@ jobs:
     - run: cargo test --features cloudflare_zlib --no-default-features
       if: matrix.build != 'mingw'
     - run: |
-        if ! cargo check --no-default-features 2>&1 | grep "You need to choose"; then 
+        if ! cargo check --no-default-features 2>&1 | grep "You need to choose"; then
           echo "expected message stating a zlib backend must be chosen"
           exit 1
         fi
-      if: matrix.build == 'stable' 
+      if: matrix.build == 'stable'
 
   rustfmt:
     name: Rustfmt & Docs
@@ -75,3 +74,16 @@ jobs:
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
     - run: cargo build --target ${{ matrix.target }}
+
+  minimum:
+    name: Minimum Rust compiler
+    runs-on: ubuntu-latest
+    env:
+      # If this is changed to pass tests, then set `rust-version` in `Cargo.toml` to the same version.
+      version: 1.56.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust (rustup)
+        run: rustup update ${version} --no-self-update && rustup default ${version}
+        shell: bash
+      - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "1.0.31"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+rust-version = "1.56.1"
 keywords = ["gzip", "deflate", "zlib", "zlib-ng", "encoding"]
 categories = ["compression", "api-bindings"]
 repository = "https://github.com/rust-lang/flate2-rs"

--- a/README.md
+++ b/README.md
@@ -23,9 +23,18 @@ flate2 = "1.0"
 
 ## MSRV (Minimum Supported Rust Version) Policy
 
-This crate supports the current stable and the last stable for the latest version.
-For example, if the current stable is 1.64, this crate supports 1.64 and 1.63.
-Older stables may work, but we don't guarantee these will continue to work.
+This crate supports the current and previous stable versions of the Rust compiler.
+For example, if the current stable is 1.80, this crate supports 1.80 and 1.79.
+
+Other compiler versions may work, but failures may not be treated as a `flate2` bug.
+
+The `Cargo.toml` file specifies a `rust-version` for which builds of the current version
+passed at some point. This value is indicative only, and may change at any time.
+
+The `rust-version` is a best-effort measured value and is different to the MSRV. The
+`rust-version` can be incremented by a PR in order to pass tests, as long as the MSRV
+continues to hold. When the `rust-version` increases, the next release should be a minor
+version, to allow any affected users to pin to a previous minor version.
 
 ## Compression
 


### PR DESCRIPTION
Specify a minimum version of the Rust compiler that successfully builds the crate. This allows us to be aware if the minimal version increases and to avoid issues such as https://github.com/rust-lang/flate2-rs/issues/370

The minimum version is a best-effort measured value and is different to the MSRV which is a support guarantee. The minimum version can be incremented by a PR in order to pass tests, as long as the MSRV holds. When the minimum version increases, the next release should be a minor version, to allow any affected users to pin to a previous minor version.