### PR TITLE
Remove non-existent build in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, beta, nightly, minimal, macos, windows, mingw]
+        build: [stable, beta, nightly, macos, windows, mingw]
         include:
           - build: stable
             os: ubuntu-latest


### PR DESCRIPTION
`minimal` build was mistakenly left in the previous commit.