### PR TITLE
increase minimal versions of `libz-ng-sys` and `libz-sys` to their latest releases.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ and raw deflate streams.
 exclude = [".*"]
 
 [dependencies]
-libz-sys = { version = "1.1.8", optional = true, default-features = false }
-libz-ng-sys = { version = "1.1.8", optional = true }
+libz-sys = { version = "1.1.19", optional = true, default-features = false }
+libz-ng-sys = { version = "1.1.15", optional = true }
 libz-rs-sys = { version = "0.2.1", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.0", optional = true }
 miniz_oxide = { version = "0.8.0", optional = true, default-features = false, features = ["with-alloc"] }


### PR DESCRIPTION
That way, those compiling with `-Zminimal-versions` have higher chances of it to work.

See https://github.com/Byron/gitoxide/pull/1541 for reference.
