### PR TITLE
Fix msrv: Run msrv checks with minimal versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,3 +93,10 @@ jobs:
           cargo +nightly update -Zminimal-versions
         shell: bash
       - run: cargo build
+      - run: cargo build --features zlib
+      - run: cargo build --features zlib --no-default-features
+      - run: cargo build --features zlib-default --no-default-features
+      - run: cargo build --features zlib-ng-compat --no-default-features
+      - run: cargo build --features zlib-ng --no-default-features
+      - run: cargo build --features zlib-rs --no-default-features
+      - run: cargo build --features cloudflare_zlib --no-default-features

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust (rustup)
-        run: rustup update ${version} --no-self-update && rustup default ${version}
+        run: |
+          rustup toolchain install ${version} nightly --profile minimal --no-self-update
+          rustup default ${version}
+          cargo +nightly update -Zminimal-versions
         shell: bash
       - run: cargo build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,10 @@ jobs:
 
   minimum:
     name: Minimum Rust compiler
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2022, macos-latest, ubuntu-latest]
     env:
       # If this is changed to pass tests, then set `rust-version` in `Cargo.toml` to the same version.
       version: 1.56.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
         os: [windows-2022, macos-latest, ubuntu-latest]
     env:
       # If this is changed to pass tests, then set `rust-version` in `Cargo.toml` to the same version.
-      version: 1.56.1
+      version: 1.63.0
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust (rustup)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,5 +98,4 @@ jobs:
       - run: cargo build --features zlib-default --no-default-features
       - run: cargo build --features zlib-ng-compat --no-default-features
       - run: cargo build --features zlib-ng --no-default-features
-      - run: cargo build --features zlib-rs --no-default-features
       - run: cargo build --features cloudflare_zlib --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ and raw deflate streams.
 exclude = [".*"]
 
 [dependencies]
-libz-sys = { version = "1.1.8", optional = true, default-features = false }
-libz-ng-sys = { version = "1.1.8", optional = true }
+libz-sys = { version = "1.1.20", optional = true, default-features = false }
+libz-ng-sys = { version = "1.1.16", optional = true }
 libz-rs-sys = { version = "0.2.1", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.0", optional = true }
 miniz_oxide = { version = "0.8.0", optional = true, default-features = false, features = ["with-alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
-version = "1.0.32"
+version = "1.0.33"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Since it is possible to for dependencies to bump MSRV in patch release, msrv checking should use the minimal versions supported by flate2.

Users cares deeply about msrv can also pin them to the minimal versions to maintain their current msrv.

This would have also help discover bugs in #424