### PR TITLE
Add minimum build test back in to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,6 @@ jobs:
       matrix:
         os: [windows-2022, macos-latest, ubuntu-latest]
     env:
-      # If this is changed to pass tests, then set `rust-version` in `Cargo.toml` to the same version.
       version: 1.63.0
     steps:
       - uses: actions/checkout@v4
@@ -99,3 +98,17 @@ jobs:
       - run: cargo build --features zlib-ng-compat --no-default-features
       - run: cargo build --features zlib-ng --no-default-features
       - run: cargo build --features cloudflare_zlib --no-default-features
+
+  # Minimum Rust compiler to build `flate2` with no optional features
+  minimum-build:
+    name: Minimum Rust compiler
+    runs-on: ubuntu-latest
+    env:
+      # If this is changed to pass tests, then set `rust-version` in `Cargo.toml` to the same version.
+      version: 1.56.1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust (rustup)
+        run: rustup update ${version} --no-self-update && rustup default ${version}
+        shell: bash
+      - run: cargo build


### PR DESCRIPTION
This test ensures that the crate builds with the default features for the compiler version listed in `rust-version`.