### PR TITLE
docs: fix compression level range from 0-9 to 0-10

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,10 @@ impl Compression {
     ///
     /// The integer here is typically on a scale of 0-9 where 0 means "no
     /// compression" and 9 means "take as long as you'd like".
+    ///
+    /// It is worth noting that `flate2` supports both `zlib` and `miniz`
+    /// backends for compression, where `miniz` also provides a level `10` of
+    /// compression.
     pub const fn new(level: u32) -> Compression {
         Compression(level)
     }
@@ -213,7 +217,7 @@ impl Compression {
     }
 
     /// Returns an integer representing the compression level, typically on a
-    /// scale of 0-9
+    /// scale of 0-9. With `miniz` backend, level 10 is also possible.
     pub fn level(&self) -> u32 {
         self.0
     }


### PR DESCRIPTION
Also store the min, max, and default levels as constants. While calling `Compression::new`, assert that level is in range.

### What's the PR for?

The docs say that compression level falls in the range `0-9` (inclusive), however, calling `Compression::new(10)` works, and there's an assertion, `debug_assert!(level.level() <= 10);` inside `ffi::rust::DeflateBackend::make` which ensures the limit is 10.

Hence the documentation is wrong. I've fixed the documentation as well as make a few minor changes.