### PR TITLE
Upgrade zlib-rs to 0.3.0 to get multiple bugfixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
-version = "1.0.33"
+version = "1.0.34"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [".*"]
 [dependencies]
 libz-sys = { version = "1.1.20", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.16", optional = true }
-libz-rs-sys = { version = "0.2.1", optional = true, default-features = false, features = ["std", "rust-allocator"] }
+libz-rs-sys = { version = "0.3.0", optional = true, default-features = false, features = ["std", "rust-allocator"] } # this matches the default features, but we don't want to depend on the default features staying the same
 cloudflare-zlib-sys = { version = "0.3.0", optional = true }
 miniz_oxide = { version = "0.8.0", optional = true, default-features = false, features = ["with-alloc"] }
 crc32fast = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ exclude = [".*"]
 [dependencies]
 libz-sys = { version = "1.1.20", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.16", optional = true }
-libz-rs-sys = { version = "0.3.0", optional = true, default-features = false, features = ["std", "rust-allocator"] } # this matches the default features, but we don't want to depend on the default features staying the same
+# this matches the default features, but we don't want to depend on the default features staying the same
+libz-rs-sys = { version = "0.3.0", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.0", optional = true }
 miniz_oxide = { version = "0.8.0", optional = true, default-features = false, features = ["with-alloc"] }
 crc32fast = "1.2.0"

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -447,7 +447,7 @@ mod c_backend {
     #[cfg(feature = "zlib-ng")]
     const ZLIB_VERSION: &'static str = "2.1.0.devel\0";
     #[cfg(all(not(feature = "zlib-ng"), feature = "zlib-rs"))]
-    const ZLIB_VERSION: &'static str = "0.1.0\0";
+    const ZLIB_VERSION: &'static str = "1.3.0-zlib-rs-0.3.0\0";
     #[cfg(not(any(feature = "zlib-ng", feature = "zlib-rs")))]
     const ZLIB_VERSION: &'static str = "1.2.8\0";
 


### PR DESCRIPTION
Fixes at least these correctness issues:

https://github.com/memorysafety/zlib-rs/pull/165
https://github.com/memorysafety/zlib-rs/issues/169
https://github.com/memorysafety/zlib-rs/issues/172

And possibly others.