### PR TITLE
Upgrade actions/upload-artifact

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,7 +19,7 @@ jobs:
         dry-run: false
         language: rust
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
GitHub has announced that v3 of the [actions/upload-artifact] action will be deprecated on November 30, 2024[^1]. The action has been upgraded to its most recent version to continue functioning after this date.

[actions/upload-artifact]: https://github.com/actions/upload-artifact
[^1]: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions