### PR TITLE
upgrade zlib-rs to version `0.4.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
-version = "1.0.34"
+version = "1.0.35"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -22,7 +22,7 @@ exclude = [".*"]
 libz-sys = { version = "1.1.20", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.16", optional = true }
 # this matches the default features, but we don't want to depend on the default features staying the same
-libz-rs-sys = { version = "0.3.0", optional = true, default-features = false, features = ["std", "rust-allocator"] }
+libz-rs-sys = { version = "0.4.0", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.0", optional = true }
 miniz_oxide = { version = "0.8.0", optional = true, default-features = false, features = ["with-alloc"] }
 crc32fast = "1.2.0"

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -447,7 +447,7 @@ mod c_backend {
     #[cfg(feature = "zlib-ng")]
     const ZLIB_VERSION: &'static str = "2.1.0.devel\0";
     #[cfg(all(not(feature = "zlib-ng"), feature = "zlib-rs"))]
-    const ZLIB_VERSION: &'static str = "1.3.0-zlib-rs-0.3.0\0";
+    const ZLIB_VERSION: &'static str = "1.3.0-zlib-rs-0.4.0\0";
     #[cfg(not(any(feature = "zlib-ng", feature = "zlib-rs")))]
     const ZLIB_VERSION: &'static str = "1.2.8\0";
 


### PR DESCRIPTION
fixes a stack overflow on malicious input https://github.com/trifectatechfoundation/zlib-rs/security/advisories/GHSA-j3px-q95c-9683