### PR TITLE
Implement `Clone` for `CompressError` and `DecompressError`

### DIFF
--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -8,7 +8,7 @@ use std::ptr;
 use super::*;
 use crate::mem;
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ErrorMessage(Option<&'static str>);
 
 impl ErrorMessage {

--- a/src/ffi/rust.rs
+++ b/src/ffi/rust.rs
@@ -17,7 +17,7 @@ use super::*;
 use crate::mem;
 
 // miniz_oxide doesn't provide any error messages (yet?)
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ErrorMessage;
 
 impl ErrorMessage {

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -109,7 +109,7 @@ pub enum FlushDecompress {
 }
 
 /// The inner state for an error when decompressing
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum DecompressErrorInner {
     General { msg: ErrorMessage },
     NeedsDictionary(u32),
@@ -117,7 +117,7 @@ pub(crate) enum DecompressErrorInner {
 
 /// Error returned when a decompression object finds that the input stream of
 /// bytes was not a valid input stream of bytes.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DecompressError(pub(crate) DecompressErrorInner);
 
 impl DecompressError {
@@ -147,7 +147,7 @@ pub(crate) fn decompress_need_dict<T>(adler: u32) -> Result<T, DecompressError> 
 
 /// Error returned when a compression object is used incorrectly or otherwise
 /// generates an error.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CompressError {
     pub(crate) msg: ErrorMessage,
 }


### PR DESCRIPTION
When making my own error types, one of my variants wraps a `flate2::DecompressError`, and that prevents me from deriving `Clone` on my error type without creating a mirror implementation and transforming between the `flate2` type and my copy of it. These two error types are cheap to clone and `Status` already derives `Clone`, too.

I didn't add a `Copy` derive because the `ErrorMessage` struct might be changed to contain a string in the future, which would break the `Copy` implementation.