### PR TITLE
Do not use cloudflare-zlib-sys 0.3.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,7 @@ jobs:
     - run: cargo test --features zlib-rs --no-default-features
       if: matrix.build != 'mingw'
     - run: cargo test --features cloudflare_zlib --no-default-features
-      # cloudflare doesn't seem to work on CI anymore for some reason, it's not reproducible locally.
-      if: matrix.build != 'mingw' && matrix.os != 'ubuntu-latest' && matrix.os != 'windows-2022'
+      if: matrix.build != 'mingw'
     - run: |
         if ! cargo check --no-default-features 2>&1 | grep "You need to choose"; then
           echo "expected message stating a zlib backend must be chosen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libz-sys = { version = "1.1.20", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.16", optional = true }
 # this matches the default features, but we don't want to depend on the default features staying the same
 libz-rs-sys = { version = "0.4.0", optional = true, default-features = false, features = ["std", "rust-allocator"] }
-cloudflare-zlib-sys = { version = "0.3.0", optional = true }
+cloudflare-zlib-sys = { version = "0.3.5", optional = true }
 miniz_oxide = { version = "0.8.0", optional = true, default-features = false, features = ["with-alloc"] }
 crc32fast = "1.2.0"
 


### PR DESCRIPTION
`cloudflare-zlib-sys` released a new version at the same time that tests started failing. Rather than stop testing cloudflare_zlib, can we pin to the previous version that succeeds in CI? With this restriction encoded in the `Cargo.toml` we avoid the possibility that this problem might be present outside GitHub CI runners and will cause real code to fail.