### PR TITLE
feat: reduce CrcReader::sum calls in GzEncoder::read_footer

### DIFF
--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -82,11 +82,12 @@ impl<R: BufRead> GzEncoder<R> {
             return Ok(0);
         }
         let crc = self.inner.get_ref().crc();
+        let calced_crc = crc.sum();
         let ref arr = [
-            (crc.sum() >> 0) as u8,
-            (crc.sum() >> 8) as u8,
-            (crc.sum() >> 16) as u8,
-            (crc.sum() >> 24) as u8,
+            (calced_crc >> 0) as u8,
+            (calced_crc >> 8) as u8,
+            (calced_crc >> 16) as u8,
+            (calced_crc >> 24) as u8,
             (crc.amount() >> 0) as u8,
             (crc.amount() >> 8) as u8,
             (crc.amount() >> 16) as u8,

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -82,12 +82,12 @@ impl<R: BufRead> GzEncoder<R> {
             return Ok(0);
         }
         let crc = self.inner.get_ref().crc();
-        let calced_crc = crc.sum().to_le_bytes();
+        let calced_crc_bytes = crc.sum().to_le_bytes();
         let arr = [
-            calced_crc[0],
-            calced_crc[1],
-            calced_crc[2],
-            calced_crc[3],
+            calced_crc_bytes[0],
+            calced_crc_bytes[1],
+            calced_crc_bytes[2],
+            calced_crc_bytes[3],
             (crc.amount() >> 0) as u8,
             (crc.amount() >> 8) as u8,
             (crc.amount() >> 16) as u8,

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -82,18 +82,18 @@ impl<R: BufRead> GzEncoder<R> {
             return Ok(0);
         }
         let crc = self.inner.get_ref().crc();
-        let calced_crc = crc.sum();
-        let ref arr = [
-            (calced_crc >> 0) as u8,
-            (calced_crc >> 8) as u8,
-            (calced_crc >> 16) as u8,
-            (calced_crc >> 24) as u8,
+        let calced_crc = crc.sum().to_le_bytes();
+        let arr = [
+            calced_crc[0],
+            calced_crc[1],
+            calced_crc[2],
+            calced_crc[3],
             (crc.amount() >> 0) as u8,
             (crc.amount() >> 8) as u8,
             (crc.amount() >> 16) as u8,
             (crc.amount() >> 24) as u8,
         ];
-        Ok(copy(into, arr, &mut self.pos))
+        Ok(copy(into, &arr, &mut self.pos))
     }
 }
 


### PR DESCRIPTION
Reduces calls to CrcReader::sum (which clones 16 bytes).
Replaces manual shifting with rust-provided `to_le_bytes`.
Moved explicit reference from declaration to usage.

I think this would technically be a perf improvement, but there is no real world difference in it at all (godbolt [here](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QAJgAMfAQQCqAZ0wAFAB6cpvAFYgupWkwahiAV0UFSy%2BsgJ4BlRugDCqWqZYM9pJwBk8DJgAch4ARpjEkgCcpAAOqIqE9gyu7p7e8Yl2Av6BISzhkRIx1pi2yUIETMQEqR5e%2BqXlApXVBLnBYRHRVlU1demNfe0BnQXdxQCUVqimxMjsHACkUgCCSxIAzEsArABCDKgA%2BixGwPS7ACIrq7GmoQDUVAwPih4Qkw8AtEub2A%2BmTYSB5LADsexuDyhDykgIkNzB1zWCK2uwOx1OxguOyRt3uTxeVFMDGQH2%2Bv3%2BpgAHCDwZDofQCA9iJgqA9qsQQZtLiD9vToQLoRA3iwyRSKTDPkxFACqaR%2BYKBcL3p9xX8HlSpTLqfK1orFcrRaq/hKuAA2LWy3WrfWCw1ik3qiQAFktOoVV1%2BEL10I5aKknuRoNxKO2%2B0OJzO2Nxd0ezyexOQEjJP3V1Np3ptDMwTIA1lyeSKPgA6IhHehHUIATwImEUHy9CsZ7OInN%2BPLRCttuf9V2ttoFPf2XD7Xf1Q728Jx/YHUInYcuM6hns2maVGzNHMmvZxCODCLWsYJD1OATFdJ9UKJJIbq4V19J27vQcuHGmtE4O14Xg4WlIqE4AAlcwmUUWZ5kwEEth4UgCE0N9plzEAdhkD8OGdb94P/TheEUEAZDg3831IOBYBgRAUFQFhYjoCJyEoNBqNoyJiC4KlnRkGhaFrYg8IgUIsNCAJqirTgYKE5hiCrAB5UJtDKQiYMYthBGkhhaFEojSCwUJTGAZwxFoPDuF4LBMXORY/3wFlygANzrLDMDUMpTFrLCAlrNC/1oPBQmIETXCwLCCGIPAWDE3h7OIUIEkwS5MHMnzjHg6YqEMYBFAANTwTAAHdpNiRgItkQQRDEdguGdEqFGUdQsN0fRDGSswLAMXy8MgaZUFibIGGM3hUCi0KsA6j4rEwGxescBgXDcepvD8UZ8kKDIEiSAQBgaOI1t6jplu6RoJoUiphk27wml61oaj2rpIiGNozvu66ltuvRpjAuYFjegxP0wrSAI4ZkQOQB4uGLdjiykB4IFwQgSCgzYuEmXhCK0SZpgQTAmCwSIxrQjDSHCqkJGLTYpFBM0oi2cnKa2Ugfz/AHcPw2CUpI8iICQWYCDuSwKAgRiaPoYgglYRY1CpM0vjNZ0HmAZAQcq4sJF4TB8CIYbvH4UrRHESrqqUVQNC0hrSFy/zYgi99fvprCAek1zeYeVA2RaghFfB51Ieh1wmOFhGkZRlKMaxnHKEQ5DUM4Anwq4UFi1psmKappPKdBW3/pwqwWdRhDSCQlCfo4TY/sZrPc/RouVYzsuOCDojK6ixIHGdIA%3D%3D)).