### PR TITLE
feat: replace manual copy loop with rust-provided function

### DIFF
--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -10,9 +10,7 @@ use crate::Compression;
 
 fn copy(into: &mut [u8], from: &[u8], pos: &mut usize) -> usize {
     let min = cmp::min(into.len(), from.len() - *pos);
-    for (slot, val) in into.iter_mut().zip(from[*pos..*pos + min].iter()) {
-        *slot = *val;
-    }
+    into[..min].copy_from_slice(&from[*pos..*pos + min]);
     *pos += min;
     min
 }


### PR DESCRIPTION
Way quicker on debug builds, only a condition and a jump better on release (godbolt [here](https://godbolt.org/z/abKddG1vE)), I find it to be simpler than the for alternative.