### PR TITLE
feat: remove explicit default impls

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -8,7 +8,7 @@ use crc32fast::Hasher;
 /// The CRC calculated by a [`CrcReader`].
 ///
 /// [`CrcReader`]: struct.CrcReader.html
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Crc {
     amt: u32,
     hasher: Hasher,
@@ -21,12 +21,6 @@ pub struct Crc {
 pub struct CrcReader<R> {
     inner: R,
     crc: Crc,
-}
-
-impl Default for Crc {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl Crc {

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -25,11 +25,8 @@ pub struct CrcReader<R> {
 
 impl Crc {
     /// Create a new CRC.
-    pub fn new() -> Crc {
-        Crc {
-            amt: 0,
-            hasher: Hasher::new(),
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Returns the current crc32 checksum.

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -324,13 +324,7 @@ pub struct GzBuilder {
 impl GzBuilder {
     /// Create a new blank builder with no header by default.
     pub fn new() -> GzBuilder {
-        GzBuilder {
-            extra: None,
-            filename: None,
-            comment: None,
-            operating_system: None,
-            mtime: 0,
-        }
+        Self::default()
     }
 
     /// Configure the `mtime` field in the gzip header.

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -87,7 +87,7 @@ impl GzHeader {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum GzHeaderState {
     Start(u8, [u8; 10]),
     Xlen(Option<Box<Crc>>, u8, [u8; 2]),
@@ -95,13 +95,8 @@ pub enum GzHeaderState {
     Filename(Option<Box<Crc>>),
     Comment(Option<Box<Crc>>),
     Crc(Option<Box<Crc>>, u8, [u8; 2]),
+    #[default]
     Complete,
-}
-
-impl Default for GzHeaderState {
-    fn default() -> Self {
-        Self::Complete
-    }
 }
 
 #[derive(Debug, Default)]
@@ -317,19 +312,13 @@ fn corrupt() -> Error {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct GzBuilder {
     extra: Option<Vec<u8>>,
     filename: Option<CString>,
     comment: Option<CString>,
     operating_system: Option<u8>,
     mtime: u32,
-}
-
-impl Default for GzBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl GzBuilder {


### PR DESCRIPTION
`Crc`: The explicit defined impl was added in [this](https://github.com/rust-lang/flate2-rs/commit/0fa0a7b40b8e022f47b59453adda938e5156ac0f#diff-c6bca753500dc9228a31ff821b89aa10e5f37b8cb8f2fcb4dfe16693e969a1dcR26-R31) commit, not sure if there was a reason for it to not be in the derive, Hasher (crc32fast 1.2.0 at that time) had a [Default impl](https://docs.rs/crc32fast/1.2.0/crc32fast/struct.Hasher.html#implementations).

`GzHeaderState`: [here](https://github.com/rust-lang/flate2-rs/commit/68ba8f6e62c7c0a12e3a62cffa2f1cdf7d1f5f30) to build on versions older than 1.62 (?), not applicable [anymore](https://github.com/rust-lang/flate2-rs/pull/452).

`GzBuilder`: [here](https://github.com/rust-lang/flate2-rs/commit/0fa0a7b40b8e022f47b59453adda938e5156ac0f#diff-c6bca753500dc9228a31ff821b89aa10e5f37b8cb8f2fcb4dfe16693e969a1dcR26-R31) (same commit as `Crc`).

Note: as now, `default` and `new` (on `GzBuilder` and `Crc`) are the same, so I replaced explicit construction with a `default` call, please mention if this is not appropiate.