### PR TITLE
deps: bump miniz_oxide to 0.8.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ libz-ng-sys = { version = "1.1.16", optional = true }
 # this matches the default features, but we don't want to depend on the default features staying the same
 libz-rs-sys = { version = "0.4.0", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.5", optional = true }
-miniz_oxide = { version = "0.8.0", optional = true, default-features = false, features = ["with-alloc"] }
+miniz_oxide = { version = "0.8.4", optional = true, default-features = false, features = ["with-alloc"] }
 crc32fast = "1.2.0"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-miniz_oxide = { version = "0.8.0", default-features = false, features = ["with-alloc"] }
+miniz_oxide = { version = "0.8.4", default-features = false, features = ["with-alloc"] }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
Updates `miniz_oxide` from `0.8.0` to `0.8.4`, changelog [here](https://github.com/Frommi/miniz_oxide/blob/master/CHANGELOG.md#084---2025-02-11), no breaking changes, only fixes and improvements.