### PR TITLE
feat: impl From<Flush> to MZFlush

### DIFF
--- a/src/ffi/rust.rs
+++ b/src/ffi/rust.rs
@@ -136,7 +136,7 @@ impl From<FlushCompress> for MZFlush {
     fn from(value: FlushCompress) -> Self {
         match value {
             FlushCompress::None => Self::None,
-            FlushCompress::Sync | FlushCompress::Partial => Self::Sync,
+            FlushCompress::Partial | FlushCompress::Sync => Self::Sync,
             FlushCompress::Full => Self::Full,
             FlushCompress::Finish => Self::Finish,
         }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -52,9 +52,9 @@ pub enum FlushCompress {
     /// All pending output is flushed to the output buffer, but the output is
     /// not aligned to a byte boundary.
     ///
-    /// All of the input data so far will be available to the decompressor (as
-    /// with `Flush::Sync`. This completes the current deflate block and follows
-    /// it with an empty fixed codes block that is 10 bites long, and it assures
+    /// All input data so far will be available to the decompressor (as with
+    /// `Flush::Sync`). This completes the current deflate block and follows it
+    /// with an empty fixed codes block that is 10 bites long, and it assures
     /// that enough bytes are output in order for the decompressor to finish the
     /// block before the empty fixed code block.
     Partial = ffi::MZ_PARTIAL_FLUSH as isize,

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -54,7 +54,7 @@ pub enum FlushCompress {
     ///
     /// All input data so far will be available to the decompressor (as with
     /// `Flush::Sync`). This completes the current deflate block and follows it
-    /// with an empty fixed codes block that is 10 bites long, and it assures
+    /// with an empty fixed codes block that is 10 bytes long, and it assures
     /// that enough bytes are output in order for the decompressor to finish the
     /// block before the empty fixed code block.
     Partial = ffi::MZ_PARTIAL_FLUSH as isize,

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -49,15 +49,6 @@ pub enum FlushCompress {
     /// accumulate before producing output in order to maximize compression.
     None = ffi::MZ_NO_FLUSH as isize,
 
-    /// All pending output is flushed to the output buffer and the output is
-    /// aligned on a byte boundary so that the decompressor can get all input
-    /// data available so far.
-    ///
-    /// Flushing may degrade compression for some compression algorithms and so
-    /// it should only be used when necessary. This will complete the current
-    /// deflate block and follow it with an empty stored block.
-    Sync = ffi::MZ_SYNC_FLUSH as isize,
-
     /// All pending output is flushed to the output buffer, but the output is
     /// not aligned to a byte boundary.
     ///
@@ -67,6 +58,15 @@ pub enum FlushCompress {
     /// that enough bytes are output in order for the decompressor to finish the
     /// block before the empty fixed code block.
     Partial = ffi::MZ_PARTIAL_FLUSH as isize,
+
+    /// All pending output is flushed to the output buffer and the output is
+    /// aligned on a byte boundary so that the decompressor can get all input
+    /// data available so far.
+    ///
+    /// Flushing may degrade compression for some compression algorithms and so
+    /// it should only be used when necessary. This will complete the current
+    /// deflate block and follow it with an empty stored block.
+    Sync = ffi::MZ_SYNC_FLUSH as isize,
 
     /// All output is flushed as with `Flush::Sync` and the compression state is
     /// reset so decompression can restart from this point if previous


### PR DESCRIPTION
We would never hit an error in building a `MZFlush`, because all values of [FlushDecompress](https://docs.rs/flate2/1.0.35/flate2/enum.FlushDecompress.html) and [FlushCompress](https://docs.rs/flate2/1.0.35/flate2/enum.FlushCompress.html) (as `i32`) map to [MZFlush](https://docs.rs/miniz_oxide/0.8.4/miniz_oxide/enum.MZFlush.html).
Implementing `From` to it is simpler and better as we get rid of the redundant `.unwrap()`s, casts to `i32` and can see directly the translation.

For more context for the mapping done here, see [MZFlush::new](https://docs.rs/miniz_oxide/0.8.4/src/miniz_oxide/lib.rs.html#69-77).