### PR TITLE
feat: make GzBuilder::filename and GzBuilder::comment results

### DIFF
--- a/examples/gzbuilder.rs
+++ b/examples/gzbuilder.rs
@@ -13,8 +13,8 @@ fn main() {
 fn sample_builder() -> Result<(), io::Error> {
     let f = File::create("examples/hello_world.txt.gz")?;
     let mut gz = GzBuilder::new()
-        .filename("hello_world.txt")
-        .comment("test file, please delete")
+        .filename("hello_world.txt")?
+        .comment("test file, please delete")?
         .write(f, Compression::default());
     gz.write_all(b"hello world")?;
     gz.finish()?;

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -346,20 +346,12 @@ impl GzBuilder {
     }
 
     /// Configure the `filename` field in the gzip header.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the `filename` slice contains a zero.
     pub fn filename<T: Into<Vec<u8>>>(mut self, filename: T) -> Result<GzBuilder> {
         self.filename = Some(CString::new(filename)?);
         Ok(self)
     }
 
     /// Configure the `comment` field in the gzip header.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the `comment` slice contains a zero.
     pub fn comment<T: Into<Vec<u8>>>(mut self, comment: T) -> Result<GzBuilder> {
         self.comment = Some(CString::new(comment)?);
         Ok(self)

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -351,7 +351,7 @@ impl GzBuilder {
     ///
     /// Panics if the `filename` slice contains a zero.
     pub fn filename<T: Into<Vec<u8>>>(mut self, filename: T) -> Result<GzBuilder> {
-        self.filename = Some(CString::new(filename.into())?);
+        self.filename = Some(CString::new(filename)?);
         Ok(self)
     }
 
@@ -361,7 +361,7 @@ impl GzBuilder {
     ///
     /// Panics if the `comment` slice contains a zero.
     pub fn comment<T: Into<Vec<u8>>>(mut self, comment: T) -> Result<GzBuilder> {
-        self.comment = Some(CString::new(comment.into())?);
+        self.comment = Some(CString::new(comment)?);
         Ok(self)
     }
 

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -304,8 +304,8 @@ fn corrupt() -> Error {
 /// # fn sample_builder() -> Result<(), io::Error> {
 /// let f = File::create("examples/hello_world.gz")?;
 /// let mut gz = GzBuilder::new()
-///                 .filename("hello_world.txt")
-///                 .comment("test file, please delete")
+///                 .filename("hello_world.txt")?
+///                 .comment("test file, please delete")?
 ///                 .write(f, Compression::default());
 /// gz.write_all(b"hello world")?;
 /// gz.finish()?;
@@ -350,9 +350,9 @@ impl GzBuilder {
     /// # Panics
     ///
     /// Panics if the `filename` slice contains a zero.
-    pub fn filename<T: Into<Vec<u8>>>(mut self, filename: T) -> GzBuilder {
-        self.filename = Some(CString::new(filename.into()).unwrap());
-        self
+    pub fn filename<T: Into<Vec<u8>>>(mut self, filename: T) -> Result<GzBuilder> {
+        self.filename = Some(CString::new(filename.into())?);
+        Ok(self)
     }
 
     /// Configure the `comment` field in the gzip header.
@@ -360,9 +360,9 @@ impl GzBuilder {
     /// # Panics
     ///
     /// Panics if the `comment` slice contains a zero.
-    pub fn comment<T: Into<Vec<u8>>>(mut self, comment: T) -> GzBuilder {
-        self.comment = Some(CString::new(comment.into()).unwrap());
-        self
+    pub fn comment<T: Into<Vec<u8>>>(mut self, comment: T) -> Result<GzBuilder> {
+        self.comment = Some(CString::new(comment.into())?);
+        Ok(self)
     }
 
     /// Consume this builder, creating a writer encoder in the process.
@@ -549,8 +549,8 @@ mod tests {
         let mut header = GzBuilder::new()
             .mtime(1234)
             .operating_system(57)
-            .filename("filename")
-            .comment("comment")
+            .filename("filename").unwrap()
+            .comment("comment").unwrap()
             .into_header(Compression::fast());
 
         // Add a CRC to the header
@@ -579,8 +579,8 @@ mod tests {
     fn fields() {
         let r = vec![0, 2, 4, 6];
         let e = GzBuilder::new()
-            .filename("foo.rs")
-            .comment("bar")
+            .filename("foo.rs").unwrap()
+            .comment("bar").unwrap()
             .extra(vec![0, 1, 2, 3])
             .read(&r[..], Compression::default());
         let mut d = read::GzDecoder::new(e);

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -549,8 +549,10 @@ mod tests {
         let mut header = GzBuilder::new()
             .mtime(1234)
             .operating_system(57)
-            .filename("filename").unwrap()
-            .comment("comment").unwrap()
+            .filename("filename")
+            .unwrap()
+            .comment("comment")
+            .unwrap()
             .into_header(Compression::fast());
 
         // Add a CRC to the header
@@ -579,8 +581,10 @@ mod tests {
     fn fields() {
         let r = vec![0, 2, 4, 6];
         let e = GzBuilder::new()
-            .filename("foo.rs").unwrap()
-            .comment("bar").unwrap()
+            .filename("foo.rs")
+            .unwrap()
+            .comment("bar")
+            .unwrap()
             .extra(vec![0, 1, 2, 3])
             .read(&r[..], Compression::default());
         let mut d = read::GzDecoder::new(e);

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -512,7 +512,7 @@ mod tests {
     fn decode_writer_partial_header_filename() {
         let filename = "test.txt";
         let mut e = GzBuilder::new()
-            .filename(filename)
+            .filename(filename).unwrap()
             .read(STR.as_bytes(), Compression::default());
         let mut bytes = Vec::new();
         e.read_to_end(&mut bytes).unwrap();
@@ -537,7 +537,7 @@ mod tests {
     fn decode_writer_partial_header_comment() {
         let comment = "test comment";
         let mut e = GzBuilder::new()
-            .comment(comment)
+            .comment(comment).unwrap()
             .read(STR.as_bytes(), Compression::default());
         let mut bytes = Vec::new();
         e.read_to_end(&mut bytes).unwrap();

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -512,7 +512,8 @@ mod tests {
     fn decode_writer_partial_header_filename() {
         let filename = "test.txt";
         let mut e = GzBuilder::new()
-            .filename(filename).unwrap()
+            .filename(filename)
+            .unwrap()
             .read(STR.as_bytes(), Compression::default());
         let mut bytes = Vec::new();
         e.read_to_end(&mut bytes).unwrap();
@@ -537,7 +538,8 @@ mod tests {
     fn decode_writer_partial_header_comment() {
         let comment = "test comment";
         let mut e = GzBuilder::new()
-            .comment(comment).unwrap()
+            .comment(comment)
+            .unwrap()
             .read(STR.as_bytes(), Compression::default());
         let mut bytes = Vec::new();
         e.read_to_end(&mut bytes).unwrap();


### PR DESCRIPTION
To handle possible panics with user-povided input, return a `Result` on [GzBuilder::comment](https://docs.rs/flate2/1.0.35/flate2/struct.GzBuilder.html#method.comment) and [GzBuilder::filename](https://docs.rs/flate2/1.0.35/flate2/struct.GzBuilder.html#method.filename).

We build a [CString](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.new), and if it fails, it returns a [NulError](https://doc.rust-lang.org/std/ffi/struct.NulError.html) which converts to [io::Error as an InvalidInput](https://doc.rust-lang.org/src/std/io/error.rs.html#100-105).

Doing so will cause breaking api changes, this is completely debatable if its worth it or not, so this PR is more like a proposal.

For more context:
The unwraps were added here: https://github.com/rust-lang/flate2-rs/commit/6430b38674655039cbe63e5b64320ff9afec45b8, back in 2015, which makes them 10-years old now.