### PR TITLE
feat: remove explicit redundant lifetime

### DIFF
--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -115,7 +115,7 @@ impl GzHeaderParser {
         }
     }
 
-    fn parse<'a, R: BufRead>(&mut self, r: &'a mut R) -> Result<()> {
+    fn parse<R: BufRead>(&mut self, r: &mut R) -> Result<()> {
         loop {
             match &mut self.state {
                 GzHeaderState::Start(count, buffer) => {


### PR DESCRIPTION
My IDE was complaining about it, its fine to do as the borrow is local only to the function call.