### PR TITLE
perf: use box instead of vec, write_all instead of loop

### DIFF
--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -48,7 +48,7 @@ fn copy(into: &mut [u8], from: &[u8], pos: &mut usize) -> usize {
 #[derive(Debug)]
 pub struct GzEncoder<R> {
     inner: deflate::bufread::DeflateEncoder<CrcReader<R>>,
-    header: Vec<u8>,
+    header: Box<[u8]>,
     pos: usize,
     eof: bool,
 }
@@ -57,7 +57,7 @@ pub fn gz_encoder<R: BufRead>(header: Vec<u8>, r: R, lvl: Compression) -> GzEnco
     let crc = CrcReader::new(r);
     GzEncoder {
         inner: deflate::bufread::DeflateEncoder::new(crc, lvl),
-        header,
+        header: header.into_boxed_slice(),
         pos: 0,
         eof: false,
     }

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -34,14 +34,14 @@ pub struct GzEncoder<W: Write> {
     inner: zio::Writer<W, Compress>,
     crc: Crc,
     crc_bytes_written: usize,
-    header: Vec<u8>,
+    header: Box<[u8]>,
 }
 
 pub fn gz_encoder<W: Write>(header: Vec<u8>, w: W, lvl: Compression) -> GzEncoder<W> {
     GzEncoder {
         inner: zio::Writer::new(w, Compress::new(lvl, false)),
         crc: Crc::new(),
-        header,
+        header: header.into_boxed_slice(),
         crc_bytes_written: 0,
     }
 }
@@ -128,10 +128,8 @@ impl<W: Write> GzEncoder<W> {
     }
 
     fn write_header(&mut self) -> io::Result<()> {
-        while !self.header.is_empty() {
-            let n = self.inner.get_mut().write(&self.header)?;
-            self.header.drain(..n);
-        }
+        self.inner.get_mut().write_all(&self.header)?;
+        self.header = [].into();
         Ok(())
     }
 }


### PR DESCRIPTION
In `bufread`:
`header` is used only for reading the data, so Boxing the slice instead of using a Vec is more memory efficient (16 vs 24).

In `write`:
As we just write until we encounter an error or empty the data, we can use `write_all` to simplify things and just reset the header afterwards, but I'm not sure if this is ok to do so, we are draining the header as we write and halt if we encounter an error, whereas this PR does not drain the data 'progressively', only if writing as a whole is successful (additional question: is this considered to be a breaking change if we change this behaviour?). 

Unfortunately I don't know enough about Gzip to conclude if this is ok or problematic, can someone clarify? While looking through the code I do have found this exact behaviour in other places and wanted to make perf PRs, but tests pass successfully and I'm not sure if these might pose problems eventually.