### PR TITLE
docs: Update README to promote zlib-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,17 @@ fn main() {
 
 ## Backends
 
-The default `miniz_oxide` backend has the advantage of being pure Rust. If you
-want maximum performance, you can use the zlib-ng C library:
+The default `miniz_oxide` backend has the advantage of being pure Rust.
+
+If you want maximum performance while still benefiting from a pure rust
+implementation, you can use `zlib-rs`:
+
+```toml
+[dependencies]
+flate2 = { version = "1.0.17", features = ["zlib-rs"], default-features = false }
+```
+
+Or, you can use the zlib-ng C library:
 
 ```toml
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,10 @@
 //!   crate which is a port of `miniz.c` (below) to Rust. This feature does not
 //!   require a C compiler and only requires Rust code.
 //!
+//! * `zlib-rs` - this implementation utilizes the `zlib-rs` crate, a pure rust rewrite of zlib.
+//!   This backend is faster than both `rust_backend` and `zlib`. However, we did not set it as the
+//!   default choice to prevent compatibility issues.
+//!
 //! * `zlib` - this feature will enable linking against the `libz` library, typically found on most
 //!   Linux systems by default. If the library isn't found to already be on the system it will be
 //!   compiled from source (this is a C library).


### PR DESCRIPTION
This PR updates the README and docs in `lib.rs` to promote `zlib-rs` instead.

Part of https://github.com/rust-lang/flate2-rs/issues/469