### PR TITLE
upgrade zlib-rs to version `0.5.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -22,7 +22,7 @@ exclude = [".*"]
 libz-sys = { version = "1.1.20", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.16", optional = true }
 # this matches the default features, but we don't want to depend on the default features staying the same
-libz-rs-sys = { version = "0.4.2", optional = true, default-features = false, features = ["std", "rust-allocator"] }
+libz-rs-sys = { version = "0.5.0", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.5", optional = true }
 miniz_oxide = { version = "0.8.5", optional = true, default-features = false, features = ["with-alloc"] }
 crc32fast = "1.2.0"

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -467,7 +467,7 @@ mod c_backend {
     #[cfg(feature = "zlib-ng")]
     const ZLIB_VERSION: &'static str = "2.1.0.devel\0";
     #[cfg(all(not(feature = "zlib-ng"), feature = "zlib-rs"))]
-    const ZLIB_VERSION: &'static str = "1.3.0-zlib-rs-0.4.2\0";
+    const ZLIB_VERSION: &'static str = "1.3.0-zlib-rs-0.5.0\0";
     #[cfg(not(any(feature = "zlib-ng", feature = "zlib-rs")))]
     const ZLIB_VERSION: &'static str = "1.2.8\0";
 


### PR DESCRIPTION
With this release, by default zlib-rs no longer exports C symbols, and hence can be used in projects that do, via some other route, include those symbols (e.g. via `libz-sys` in openssl). 