### PR TITLE
feat: simplify manual bits extraction and an unneeded reref

### DIFF
--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -303,7 +303,7 @@ impl<R: BufRead> Read for GzDecoder<R> {
                     if *pos < buf.len() {
                         *pos += read_into(self.reader.get_mut().get_mut(), &mut buf[*pos..])?;
                     } else {
-                        let (crc, amt) = finish(&buf);
+                        let (crc, amt) = finish(buf);
 
                         if crc != self.reader.crc().sum() || amt != self.reader.crc().amount() {
                             self.state = GzState::End(Some(mem::take(header)));

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -402,8 +402,7 @@ impl GzBuilder {
         let mut header = vec![0u8; 10];
         if let Some(v) = extra {
             flg |= FEXTRA;
-            header.push((v.len() >> 0) as u8);
-            header.push((v.len() >> 8) as u8);
+            header.extend((v.len() as u16).to_le_bytes());
             header.extend(v);
         }
         if let Some(filename) = filename {


### PR DESCRIPTION
```rust
let (crc, amt) = finish(&buf);
```
`finish` already takes in a reference, so this creates a needless borrow which is dereferenced at compile time.

```rust
header.push((v.len() >> 0) as u8);
header.push((v.len() >> 8) as u8);
```
is exactly the same as doing
```rust
header.extend((v.len() as u16).to_le_bytes());
```
because we dont need the full length anyways, I find the latter simpler, LLVM should solve these as exactly the same operations with optimizations on.