### PR TITLE
ci: add dependabot, with a note of keeping deps always up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Mentioned adding of dependabot in #485, but @jongiddy [said](https://github.com/rust-lang/flate2-rs/pull/485#issuecomment-2835258658) that:
> For a library crate, isn't the effect of these version updates simply to reduce the options available to dependent crates?
>
> i.e. previously flate2 was compatible with any version of libz-sys >= 1.1.20, but now it requires at least 1.1.22. If, for any reason, a crate needs to keep libz-sys at 1.1.20, it now has a conflict.
>
> I tend to update crate versions only when there is a security or bug fix reason to do so.

Should a dependency be updated as quick as possible? Or only if a user has a problem with one of them (or wants to) and requests to do so? A fixed schedule (i.e. once every 6 months)?

I personally consider that a project should always try to be up to date with the latest dependencies, but the points mentioned should be taken into consideration before merging of this PR.
