### PR TITLE
feat: solve remaining clippy warnings and add it to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         fi
       if: matrix.build == 'stable'
 
-  fmt_docs_clippy:
+  rustfmt_docs_clippy:
     name: Rustfmt, Docs and Clippy
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,15 +53,16 @@ jobs:
         fi
       if: matrix.build == 'stable'
 
-  rustfmt:
-    name: Rustfmt & Docs
+  fmt_docs_clippy:
+    name: Rustfmt, Docs and Clippy
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add rustfmt
+      run: rustup update stable && rustup default stable && rustup component add rustfmt && rustup component add clippy
     - run: cargo fmt -- --check
     - run: cargo doc --all-features
+    - run: cargo clippy --all-features -- -D warnings
 
   wasm:
     name: WebAssembly

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -287,7 +287,7 @@ impl InflateBackend for Inflate {
                 MZ_OK => Ok(Status::Ok),
                 MZ_BUF_ERROR => Ok(Status::BufError),
                 MZ_STREAM_END => Ok(Status::StreamEnd),
-                MZ_NEED_DICT => mem::decompress_need_dict((*raw).adler as u32),
+                MZ_NEED_DICT => mem::decompress_need_dict((*raw).adler),
                 c => panic!("unknown return code: {}", c),
             }
         }
@@ -465,11 +465,11 @@ mod c_backend {
     pub const MZ_DEFAULT_WINDOW_BITS: c_int = 15;
 
     #[cfg(feature = "zlib-ng")]
-    const ZLIB_VERSION: &'static str = "2.1.0.devel\0";
+    const ZLIB_VERSION: &str = "2.1.0.devel\0";
     #[cfg(all(not(feature = "zlib-ng"), feature = "zlib-rs"))]
-    const ZLIB_VERSION: &'static str = "1.3.0-zlib-rs-0.5.0\0";
+    const ZLIB_VERSION: &str = "1.3.0-zlib-rs-0.5.0\0";
     #[cfg(not(any(feature = "zlib-ng", feature = "zlib-rs")))]
-    const ZLIB_VERSION: &'static str = "1.2.8\0";
+    const ZLIB_VERSION: &str = "1.2.8\0";
 
     pub unsafe extern "C" fn mz_deflateInit2(
         stream: *mut mz_stream,

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -287,7 +287,8 @@ impl InflateBackend for Inflate {
                 MZ_OK => Ok(Status::Ok),
                 MZ_BUF_ERROR => Ok(Status::BufError),
                 MZ_STREAM_END => Ok(Status::StreamEnd),
-                MZ_NEED_DICT => mem::decompress_need_dict((*raw).adler),
+                #[allow(clippy::unnecessary_cast)]
+                MZ_NEED_DICT => mem::decompress_need_dict((*raw).adler as u32),
                 c => panic!("unknown return code: {}", c),
             }
         }

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -86,7 +86,7 @@ impl<R: BufRead> GzEncoder<R> {
             calced_crc_bytes[1],
             calced_crc_bytes[2],
             calced_crc_bytes[3],
-            (crc.amount() >> 0) as u8,
+            crc.amount() as u8,
             (crc.amount() >> 8) as u8,
             (crc.amount() >> 16) as u8,
             (crc.amount() >> 24) as u8,
@@ -117,11 +117,11 @@ impl<R> GzEncoder<R> {
 
 #[inline]
 fn finish(buf: &[u8; 8]) -> (u32, u32) {
-    let crc = ((buf[0] as u32) << 0)
+    let crc = (buf[0] as u32)
         | ((buf[1] as u32) << 8)
         | ((buf[2] as u32) << 16)
         | ((buf[3] as u32) << 24);
-    let amt = ((buf[4] as u32) << 0)
+    let amt = (buf[4] as u32)
         | ((buf[5] as u32) << 8)
         | ((buf[6] as u32) << 16)
         | ((buf[7] as u32) << 24);

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -135,7 +135,7 @@ impl GzHeaderParser {
                     if self.flags & FRESERVED != 0 {
                         return Err(bad_header());
                     }
-                    self.header.mtime = ((buffer[4] as u32) << 0)
+                    self.header.mtime = (buffer[4] as u32)
                         | ((buffer[5] as u32) << 8)
                         | ((buffer[6] as u32) << 16)
                         | ((buffer[7] as u32) << 24);
@@ -417,7 +417,7 @@ impl GzBuilder {
         header[1] = 0x8b;
         header[2] = 8;
         header[3] = flg;
-        header[4] = (mtime >> 0) as u8;
+        header[4] = mtime as u8;
         header[5] = (mtime >> 8) as u8;
         header[6] = (mtime >> 16) as u8;
         header[7] = (mtime >> 24) as u8;

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -93,11 +93,11 @@ impl<W: Write> GzEncoder<W> {
         while self.crc_bytes_written < 8 {
             let (sum, amt) = (self.crc.sum(), self.crc.amount());
             let buf = [
-                (sum >> 0) as u8,
+                sum as u8,
                 (sum >> 8) as u8,
                 (sum >> 16) as u8,
                 (sum >> 24) as u8,
-                (amt >> 0) as u8,
+                amt as u8,
                 (amt >> 8) as u8,
                 (amt >> 16) as u8,
                 (amt >> 24) as u8,
@@ -294,11 +294,11 @@ impl<W: Write> GzDecoder<W> {
             return Err(corrupt());
         }
 
-        let crc = ((self.crc_bytes[0] as u32) << 0)
+        let crc = (self.crc_bytes[0] as u32)
             | ((self.crc_bytes[1] as u32) << 8)
             | ((self.crc_bytes[2] as u32) << 16)
             | ((self.crc_bytes[3] as u32) << 24);
-        let amt = ((self.crc_bytes[4] as u32) << 0)
+        let amt = (self.crc_bytes[4] as u32)
             | ((self.crc_bytes[5] as u32) << 8)
             | ((self.crc_bytes[6] as u32) << 16)
             | ((self.crc_bytes[7] as u32) << 24);

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -43,11 +43,12 @@ pub struct Decompress {
 /// in-memory data.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[non_exhaustive]
+#[allow(clippy::unnecessary_cast)]
 pub enum FlushCompress {
     /// A typical parameter for passing to compression/decompression functions,
     /// this indicates that the underlying stream to decide how much data to
     /// accumulate before producing output in order to maximize compression.
-    None = ffi::MZ_NO_FLUSH,
+    None = ffi::MZ_NO_FLUSH as isize,
 
     /// All pending output is flushed to the output buffer, but the output is
     /// not aligned to a byte boundary.
@@ -57,7 +58,7 @@ pub enum FlushCompress {
     /// with an empty fixed codes block that is 10 bytes long, and it assures
     /// that enough bytes are output in order for the decompressor to finish the
     /// block before the empty fixed code block.
-    Partial = ffi::MZ_PARTIAL_FLUSH,
+    Partial = ffi::MZ_PARTIAL_FLUSH as isize,
 
     /// All pending output is flushed to the output buffer and the output is
     /// aligned on a byte boundary so that the decompressor can get all input
@@ -66,31 +67,32 @@ pub enum FlushCompress {
     /// Flushing may degrade compression for some compression algorithms and so
     /// it should only be used when necessary. This will complete the current
     /// deflate block and follow it with an empty stored block.
-    Sync = ffi::MZ_SYNC_FLUSH,
+    Sync = ffi::MZ_SYNC_FLUSH as isize,
 
     /// All output is flushed as with `Flush::Sync` and the compression state is
     /// reset so decompression can restart from this point if previous
     /// compressed data has been damaged or if random access is desired.
     ///
     /// Using this option too often can seriously degrade compression.
-    Full = ffi::MZ_FULL_FLUSH,
+    Full = ffi::MZ_FULL_FLUSH as isize,
 
     /// Pending input is processed and pending output is flushed.
     ///
     /// The return value may indicate that the stream is not yet done and more
     /// data has yet to be processed.
-    Finish = ffi::MZ_FINISH,
+    Finish = ffi::MZ_FINISH as isize,
 }
 
 /// Values which indicate the form of flushing to be used when
 /// decompressing in-memory data.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[non_exhaustive]
+#[allow(clippy::unnecessary_cast)]
 pub enum FlushDecompress {
     /// A typical parameter for passing to compression/decompression functions,
     /// this indicates that the underlying stream to decide how much data to
     /// accumulate before producing output in order to maximize compression.
-    None = ffi::MZ_NO_FLUSH,
+    None = ffi::MZ_NO_FLUSH as isize,
 
     /// All pending output is flushed to the output buffer and the output is
     /// aligned on a byte boundary so that the decompressor can get all input
@@ -99,13 +101,13 @@ pub enum FlushDecompress {
     /// Flushing may degrade compression for some compression algorithms and so
     /// it should only be used when necessary. This will complete the current
     /// deflate block and follow it with an empty stored block.
-    Sync = ffi::MZ_SYNC_FLUSH,
+    Sync = ffi::MZ_SYNC_FLUSH as isize,
 
     /// Pending input is processed and pending output is flushed.
     ///
     /// The return value may indicate that the stream is not yet done and more
     /// data has yet to be processed.
-    Finish = ffi::MZ_FINISH,
+    Finish = ffi::MZ_FINISH as isize,
 }
 
 /// The inner state for an error when decompressing

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -279,7 +279,8 @@ impl Compress {
 
         match rc {
             ffi::MZ_STREAM_ERROR => compress_failed(self.inner.inner.msg()),
-            ffi::MZ_OK => Ok(unsafe { (*stream).adler }),
+            #[allow(clippy::unnecessary_cast)]
+            ffi::MZ_OK => Ok(unsafe { (*stream).adler } as u32),
             c => panic!("unknown return code: {}", c),
         }
     }
@@ -495,10 +496,11 @@ impl Decompress {
             ffi::inflateSetDictionary(stream, dictionary.as_ptr(), dictionary.len() as ffi::uInt)
         };
 
+        #[allow(clippy::unnecessary_cast)]
         match rc {
             ffi::MZ_STREAM_ERROR => decompress_failed(self.inner.inner.msg()),
-            ffi::MZ_DATA_ERROR => decompress_need_dict(unsafe { (*stream).adler }),
-            ffi::MZ_OK => Ok(unsafe { (*stream).adler }),
+            ffi::MZ_DATA_ERROR => decompress_need_dict(unsafe { (*stream).adler } as u32),
+            ffi::MZ_OK => Ok(unsafe { (*stream).adler } as u32),
             c => panic!("unknown return code: {}", c),
         }
     }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -279,7 +279,7 @@ impl Compress {
 
         match rc {
             ffi::MZ_STREAM_ERROR => compress_failed(self.inner.inner.msg()),
-            ffi::MZ_OK => Ok(unsafe { (*stream).adler } as u32),
+            ffi::MZ_OK => Ok(unsafe { (*stream).adler }),
             c => panic!("unknown return code: {}", c),
         }
     }
@@ -497,8 +497,8 @@ impl Decompress {
 
         match rc {
             ffi::MZ_STREAM_ERROR => decompress_failed(self.inner.inner.msg()),
-            ffi::MZ_DATA_ERROR => decompress_need_dict(unsafe { (*stream).adler } as u32),
-            ffi::MZ_OK => Ok(unsafe { (*stream).adler } as u32),
+            ffi::MZ_DATA_ERROR => decompress_need_dict(unsafe { (*stream).adler }),
+            ffi::MZ_OK => Ok(unsafe { (*stream).adler }),
             c => panic!("unknown return code: {}", c),
         }
     }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -47,7 +47,7 @@ pub enum FlushCompress {
     /// A typical parameter for passing to compression/decompression functions,
     /// this indicates that the underlying stream to decide how much data to
     /// accumulate before producing output in order to maximize compression.
-    None = ffi::MZ_NO_FLUSH as isize,
+    None = ffi::MZ_NO_FLUSH,
 
     /// All pending output is flushed to the output buffer, but the output is
     /// not aligned to a byte boundary.
@@ -57,7 +57,7 @@ pub enum FlushCompress {
     /// with an empty fixed codes block that is 10 bytes long, and it assures
     /// that enough bytes are output in order for the decompressor to finish the
     /// block before the empty fixed code block.
-    Partial = ffi::MZ_PARTIAL_FLUSH as isize,
+    Partial = ffi::MZ_PARTIAL_FLUSH,
 
     /// All pending output is flushed to the output buffer and the output is
     /// aligned on a byte boundary so that the decompressor can get all input
@@ -66,20 +66,20 @@ pub enum FlushCompress {
     /// Flushing may degrade compression for some compression algorithms and so
     /// it should only be used when necessary. This will complete the current
     /// deflate block and follow it with an empty stored block.
-    Sync = ffi::MZ_SYNC_FLUSH as isize,
+    Sync = ffi::MZ_SYNC_FLUSH,
 
     /// All output is flushed as with `Flush::Sync` and the compression state is
     /// reset so decompression can restart from this point if previous
     /// compressed data has been damaged or if random access is desired.
     ///
     /// Using this option too often can seriously degrade compression.
-    Full = ffi::MZ_FULL_FLUSH as isize,
+    Full = ffi::MZ_FULL_FLUSH,
 
     /// Pending input is processed and pending output is flushed.
     ///
     /// The return value may indicate that the stream is not yet done and more
     /// data has yet to be processed.
-    Finish = ffi::MZ_FINISH as isize,
+    Finish = ffi::MZ_FINISH,
 }
 
 /// Values which indicate the form of flushing to be used when
@@ -90,7 +90,7 @@ pub enum FlushDecompress {
     /// A typical parameter for passing to compression/decompression functions,
     /// this indicates that the underlying stream to decide how much data to
     /// accumulate before producing output in order to maximize compression.
-    None = ffi::MZ_NO_FLUSH as isize,
+    None = ffi::MZ_NO_FLUSH,
 
     /// All pending output is flushed to the output buffer and the output is
     /// aligned on a byte boundary so that the decompressor can get all input
@@ -99,13 +99,13 @@ pub enum FlushDecompress {
     /// Flushing may degrade compression for some compression algorithms and so
     /// it should only be used when necessary. This will complete the current
     /// deflate block and follow it with an empty stored block.
-    Sync = ffi::MZ_SYNC_FLUSH as isize,
+    Sync = ffi::MZ_SYNC_FLUSH,
 
     /// Pending input is processed and pending output is flushed.
     ///
     /// The return value may indicate that the stream is not yet done and more
     /// data has yet to be processed.
-    Finish = ffi::MZ_FINISH as isize,
+    Finish = ffi::MZ_FINISH,
 }
 
 /// The inner state for an error when decompressing


### PR DESCRIPTION
Other than quite a few usages of `#[allow(clippy::unnecessary_cast)]` cause clippy can't fully see the full picture, things look fine to me.
Many of my contributions contained clippy warning fixes and this PR solves all of the remaining ones and adds check for them to CI (as errors).