### PR TITLE
ci: add audit check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,20 @@ jobs:
     - run: cargo doc --all-features
     - run: cargo clippy --all-features -- -D warnings
 
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate Cargo.lock # explicitly generate the lockfile, see https://github.com/rustsec/audit-check/issues/27
+        run: cargo generate-lockfile
+
+      - name: Audit Check
+        uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   wasm:
     name: WebAssembly
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
     - run: cargo clippy --all-features -- -D warnings
 
   audit:
-    name: Audit
+    name: Security Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Mentioned in #485, as a result of the discussions there this replaces #486 (dependabot updates).