### PR TITLE
feat: revert most recent deps updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,16 +19,16 @@ and raw deflate streams.
 exclude = [".*"]
 
 [dependencies]
-libz-sys = { version = "1.1.22", optional = true, default-features = false }
-libz-ng-sys = { version = "1.1.22", optional = true }
+libz-sys = { version = "1.1.20", optional = true, default-features = false }
+libz-ng-sys = { version = "1.1.16", optional = true }
 # this matches the default features, but we don't want to depend on the default features staying the same
 libz-rs-sys = { version = "0.5.0", optional = true, default-features = false, features = ["std", "rust-allocator"] }
-cloudflare-zlib-sys = { version = "0.3.6", optional = true }
-miniz_oxide = { version = "0.8.8", optional = true, default-features = false, features = ["with-alloc"] }
-crc32fast = "1.4.2"
+cloudflare-zlib-sys = { version = "0.3.5", optional = true }
+miniz_oxide = { version = "0.8.5", optional = true, default-features = false, features = ["with-alloc"] }
+crc32fast = "1.2.0"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-miniz_oxide = { version = "0.8.8", default-features = false, features = ["with-alloc"] }
+miniz_oxide = { version = "0.8.5", default-features = false, features = ["with-alloc"] }
 
 [dev-dependencies]
 rand = "0.9"


### PR DESCRIPTION
This reverts commit 500b61c093c4a837e02dabf57d001cd6cd0303e9.

For more context to see why this is happening, see #488 and the linked references there too.