### PR TITLE
use `zlibVersion()` instead of a `const` for the version

### DIFF
--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -465,13 +465,6 @@ mod c_backend {
 
     pub const MZ_DEFAULT_WINDOW_BITS: c_int = 15;
 
-    #[cfg(feature = "zlib-ng")]
-    const ZLIB_VERSION: &str = "2.1.0.devel\0";
-    #[cfg(all(not(feature = "zlib-ng"), feature = "zlib-rs"))]
-    const ZLIB_VERSION: &str = "1.3.0-zlib-rs-0.5.1\0";
-    #[cfg(not(any(feature = "zlib-ng", feature = "zlib-rs")))]
-    const ZLIB_VERSION: &str = "1.2.8\0";
-
     pub unsafe extern "C" fn mz_deflateInit2(
         stream: *mut mz_stream,
         level: c_int,
@@ -487,7 +480,7 @@ mod c_backend {
             window_bits,
             mem_level,
             strategy,
-            ZLIB_VERSION.as_ptr() as *const c_char,
+            zlibVersion(),
             mem::size_of::<mz_stream>() as c_int,
         )
     }
@@ -495,7 +488,7 @@ mod c_backend {
         libz::inflateInit2_(
             stream,
             window_bits,
-            ZLIB_VERSION.as_ptr() as *const c_char,
+            zlibVersion(),
             mem::size_of::<mz_stream>() as c_int,
         )
     }


### PR DESCRIPTION
I don't think there is any downside to just using these functions really. Technically it's an extra function call (unless LTO is able to remove it, I guess). For zlib-rs, the function can just be inlined (it's a `const fn` even).