### PR TITLE
Switch from adler2 to simd-adler32 crate when using miniz_oxide backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ libz-ng-sys = { version = "1.1.16", optional = true }
 # this matches the default features, but we don't want to depend on the default features staying the same
 libz-rs-sys = { version = "0.5.1", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.5", optional = true }
-miniz_oxide = { version = "0.8.5", optional = true, default-features = false, features = ["with-alloc"] }
+miniz_oxide = { version = "0.8.5", optional = true, default-features = false, features = ["with-alloc", "simd"] }
 crc32fast = "1.2.0"
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-miniz_oxide = { version = "0.8.5", default-features = false, features = ["with-alloc"] }
+miniz_oxide = { version = "0.8.5", default-features = false, features = ["with-alloc", "simd"] }
 
 [dev-dependencies]
 rand = "0.9"


### PR DESCRIPTION
Switch over to https://crates.io/crates/simd-adler32 for a performance boost.

Introduces some unsafe code into the dependency tree due to the use of raw CPU intrinsics. However, this unsafe code is low risk due to the way it's structured, and the crate has also undergone extensive fuzzing.

This has been enabled in the famously risk-averse `image-png` for a good while now, and is even enabled in the Chromium field trials on stable channel.

It's worth noting that Rust v1.87 has dramatically regressed performance of lots of SIMD code relying on runtime feature etection; this negatively affected the AVX2 codepath of simd-adler32, see https://github.com/rust-lang/rust/issues/142603
Which is why I didn't open this earlier.

On all other compiler versions dating back all the way to MSRV this crate is dramatically faster than adler2.