### PR TITLE
Correct documentation typo

### DIFF
--- a/src/mem.rs
+++ b/src/mem.rs
@@ -55,7 +55,7 @@ pub enum FlushCompress {
     ///
     /// All input data so far will be available to the decompressor (as with
     /// `Flush::Sync`). This completes the current deflate block and follows it
-    /// with an empty fixed codes block that is 10 bytes long, and it assures
+    /// with an empty fixed codes block that is 10 bits long, and it assures
     /// that enough bytes are output in order for the decompressor to finish the
     /// block before the empty fixed code block.
     Partial = ffi::MZ_PARTIAL_FLUSH as isize,


### PR DESCRIPTION
As described [here](https://www.bolet.org/~pornin/deflate-flush.html) a partial flush involves writing one or two empty 10 _bit_ fixed code blocks.