### PR TITLE
Use partial flushes with miniz_oxide backend

### DIFF
--- a/src/ffi/rust.rs
+++ b/src/ffi/rust.rs
@@ -136,7 +136,8 @@ impl From<FlushCompress> for MZFlush {
     fn from(value: FlushCompress) -> Self {
         match value {
             FlushCompress::None => Self::None,
-            FlushCompress::Partial | FlushCompress::Sync => Self::Sync,
+            FlushCompress::Partial => Self::Partial,
+            FlushCompress::Sync => Self::Sync,
             FlushCompress::Full => Self::Full,
             FlushCompress::Finish => Self::Finish,
         }


### PR DESCRIPTION
I'll admit that I don't quite know why the code previously mapped `FlushCompress::Partial` to a sync flush