### PR TITLE
Undo introducing straight up incorrect documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,18 +190,6 @@ impl Compression {
     ///
     /// The integer here is typically on a scale of 0-9 where 0 means "no
     /// compression" and 9 means "take as long as you'd like".
-    ///
-    /// ### Backend differences
-    ///
-    /// The [`miniz_oxide`](https://crates.io/crates/miniz_oxide) backend for flate2
-    /// does not support level 0 or `Compression::none()`. Instead it interprets them
-    /// as the default compression level, which is quite slow.
-    /// `Compression::fast()` should be used instead.
-    ///
-    /// `miniz_oxide` also supports a non-compliant compression level 10.
-    /// It is even slower and may result in higher compression, but
-    /// **only miniz_oxide will be able to read the data** compressed with level 10.
-    /// Do **not** use level 10 if you need other software to be able to read it!
     pub const fn new(level: u32) -> Compression {
         Compression(level)
     }


### PR DESCRIPTION
Undo introducing misleading documentation, following the clarifications from miniz_oxide author in https://github.com/rust-lang/flate2-rs/pull/430#issuecomment-3091572081

I think it is still desirable to have some support for miniz_oxide level 10, but doing it properly will require code changes and not just documentation. For example, letting the API user set 10 and automatically lowering it to 9 when using one of the zlib backends, so that Cargo feature unification wouldn't outright break people's code. That will need some API design work, so I want to get the misleading docs out of the way ASAP. Sorry :sweat: 