### PR TITLE
Upgrade miniz_oxide and add unit tests of the different flush kinds

### DIFF
--- a/src/ffi/miniz_oxide.rs
+++ b/src/ffi/miniz_oxide.rs
@@ -136,7 +136,8 @@ impl From<FlushCompress> for MZFlush {
     fn from(value: FlushCompress) -> Self {
         match value {
             FlushCompress::None => Self::None,
-            FlushCompress::Partial | FlushCompress::Sync => Self::Sync,
+            FlushCompress::Partial => Self::Partial,
+            FlushCompress::Sync => Self::Sync,
             FlushCompress::Full => Self::Full,
             FlushCompress::Finish => Self::Finish,
         }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -663,7 +663,6 @@ mod tests {
     use crate::write;
     use crate::{Compression, Decompress, FlushDecompress};
 
-    #[cfg(feature = "any_zlib")]
     use crate::{Compress, FlushCompress};
 
     #[test]
@@ -761,5 +760,67 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.message(), Some("invalid stored block lengths"));
+    }
+
+    fn compress_with_flush(flush: FlushCompress) -> Vec<u8> {
+        let incompressible = (0..=255).collect::<Vec<u8>>();
+        let mut output = vec![0; 1024];
+
+        // Feed in the incompressible data followed by the indicated flush type.
+        let mut w = Compress::new(Compression::default(), false);
+        w.compress(&incompressible, &mut output, flush).unwrap();
+
+        if flush != FlushCompress::None {
+            // The first instance of incompressible input should have been written uncompressed.
+            assert!(w.total_out() >= 261);
+            assert_eq!(&output[0..5], &[0, 0, 1, 0xff, !1]);
+            assert_eq!(&output[5..261], &incompressible);
+        }
+
+        // Feed in the same data again.
+        let len = w.total_out() as usize;
+        w.compress(&incompressible, &mut output[len..], FlushCompress::Finish)
+            .unwrap();
+
+        if flush != FlushCompress::Full {
+            // This time, the data should have been compressed (because it is an exact duplicate of
+            // the earlier block).
+            assert!(w.total_out() < 300);
+        }
+
+        // Assert that all input has been processed.
+        assert_eq!(w.total_in(), 256 * 2);
+
+        output.resize(w.total_out() as usize, 0);
+        output
+    }
+
+    #[test]
+    fn test_partial_flush() {
+        let output = compress_with_flush(FlushCompress::Partial);
+
+        // Check for partial flush marker.
+        assert_eq!(output[261], 0x2);
+        assert_eq!(output[262] & 0x7, 0x4);
+    }
+
+    #[test]
+    fn test_sync_flush() {
+        let output = compress_with_flush(FlushCompress::Sync);
+
+        // Check for sync flush marker.
+        assert_eq!(&output[261..][..5], &[0, 0, 0, 0xff, 0xff]);
+    }
+
+    #[test]
+    fn test_full_flush() {
+        let output = compress_with_flush(FlushCompress::Full);
+        assert_eq!(output.len(), 527);
+
+        // Check for sync flush marker.
+        assert_eq!(&output[261..][..5], &[0, 0, 0, 0xff, 0xff]);
+
+        // Check that the second instance of incompressible input was also written uncompressed.
+        assert_eq!(&output[266..][..5], &[1, 0, 1, 0xff, !1]);
     }
 }


### PR DESCRIPTION
This PR adds tests of the various flush kinds to ensure that all backends implement them consistently. The cases are carefully constructed so that even quite different backend implementations are likely to produce the expected output. In particular, it counts on the encoder detecting when the input is/isn't compressible and writing either compressed or stored blocks accordingly.  

Tests pass for me with the `zlib`, `zlib-ng`, `zlib-rs` and `cloudflare_zlib` backends. The `miniz_oxide` backend requires https://github.com/Frommi/miniz_oxide/pull/179 as otherwise it treats partial flushes as "no flush" (!)