### PR TITLE
use Decompress::reset() instead of recreating in DeflateDecoder

### DIFF
--- a/src/deflate/bufread.rs
+++ b/src/deflate/bufread.rs
@@ -166,7 +166,7 @@ pub struct DeflateDecoder<R> {
 }
 
 pub fn reset_decoder_data<R>(zlib: &mut DeflateDecoder<R>) {
-    zlib.data = Decompress::new(false);
+    zlib.data.reset(false);
 }
 
 impl<R: BufRead> DeflateDecoder<R> {


### PR DESCRIPTION
From https://www.zlib.net/manual.html

> This function is equivalent to inflateEnd followed by inflateInit, but does not free and reallocate the internal decompression state. The The stream will keep attributes that may have been set by inflateInit2. total_in, total_out, adler, and msg are initialized.

This led to a ~14% performance improvement on my workloads with `MultiGZDecoder`.