### PR TITLE
upgrade zlib-rs to version `0.6.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Josh Triplett <josh@joshtriplett.org>"]
-version = "1.1.8"
+version = "1.1.9"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -22,7 +22,7 @@ exclude = [".*"]
 libz-sys = { version = "1.1.20", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.16", optional = true }
 # this matches the default features, but we don't want to depend on the default features staying the same
-zlib-rs = { version = "0.5.5", optional = true, default-features = false, features = ["std", "rust-allocator"] }
+zlib-rs = { version = "0.6.0", optional = true, default-features = false, features = ["std", "rust-allocator"] }
 cloudflare-zlib-sys = { version = "0.3.6", optional = true }
 ## This implementation uses only safe Rust code and doesn't require a C compiler.
 ## It provides good performance for most use cases while being completely portable.


### PR DESCRIPTION
https://github.com/trifectatechfoundation/zlib-rs/releases/tag/v0.6.0

Not that eventful from the flate2 perspective. When compiling with avx512 compression should be a bit faster.