### PR TITLE
feat: reuse zlib's decoder buffer

### DIFF
--- a/src/zlib/bufread.rs
+++ b/src/zlib/bufread.rs
@@ -193,7 +193,7 @@ impl<R: BufRead> ZlibDecoder<R> {
 }
 
 pub fn reset_decoder_data<R>(zlib: &mut ZlibDecoder<R>) {
-    zlib.data = Decompress::new(true);
+    zlib.data.reset(true);
 }
 
 impl<R> ZlibDecoder<R> {


### PR DESCRIPTION
this optimization removes an extra allocation when `ZlibDecoder` is reused via reset method.

a similar optimization has been applied to deflate decoder already in https://github.com/rust-lang/flate2-rs/commit/e1b7656cd2724dcd74177756ebd3feb3800c8878
