### PR TITLE
PoC: Add fdeflate as a new backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ and raw deflate streams.
 exclude = [".*"]
 
 [dependencies]
+fdeflate = { git = "https://github.com/Shnatsel/fdeflate.git", branch = "raw-deflate", optional = true }
 libz-sys = { version = "1.1.20", optional = true, default-features = false }
 libz-ng-sys = { version = "1.1.16", optional = true }
 # this matches the default features, but we don't want to depend on the default features staying the same
@@ -87,6 +88,11 @@ zlib-ng = ["any_c_zlib", "libz-ng-sys", "dep:crc32fast"]
 ## Cloudflare-zlib is no longer supported.
 ## Falls back to `libz-sys`, but we recommend switching to `zlib-rs` instead.
 cloudflare_zlib = ["zlib"]
+
+## Use the `fdeflate` backend, a fast pure Rust deflate implementation.
+## This implementation uses only safe Rust code and doesn't require a C compiler.
+## It is optimized for speed and provides good compression performance.
+fdeflate = ["any_impl", "dep:fdeflate", "dep:crc32fast"]
 
 ## Deprecated alias for `rust_backend`, provided for backwards compatibility.
 ## Use `rust_backend` instead.

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -178,6 +178,18 @@ mod tests {
     }
 
     #[test]
+    fn debug_single_byte() {
+        let v = vec![0u8];
+        let mut w = write::DeflateEncoder::new(
+            write::DeflateDecoder::new(Vec::new()),
+            Compression::default(),
+        );
+        w.write_all(&v).unwrap();
+        let result = w.finish().unwrap().finish().unwrap();
+        assert_eq!(v, result);
+    }
+
+    #[test]
     fn qc_writer() {
         ::quickcheck::quickcheck(test as fn(_) -> _);
 

--- a/src/ffi/fdeflate.rs
+++ b/src/ffi/fdeflate.rs
@@ -164,15 +164,21 @@ impl Backend for Inflate {
 
 /// Wraps fdeflate's Compressor to implement the streaming DeflateBackend interface.
 ///
-/// fdeflate's Compressor takes a `Write` target and has `write_data`/`finish` methods.
-/// We use a `Vec<u8>` as the internal output buffer. Since fdeflate writes compressed
-/// data to the writer during `write_data` and `finish` calls, we buffer that output
-/// and drain it into the caller's output buffer on each `compress` call.
+/// fdeflate's Compressor writes compressed data to its inner `Vec<u8>` writer
+/// incrementally during `write_data()` calls. After each call, we drain the
+/// writer's buffer directly into the caller's output slice, avoiding any
+/// secondary buffering.
+///
+/// After `finish()` is called, any remaining compressed data that didn't fit
+/// in the caller's output is held in `finished_buf` until drained.
 pub struct Deflate {
-    /// Buffered compressed output that hasn't been returned to the caller yet.
-    output_buf: Vec<u8>,
     /// The compressor state. Set to `None` after `finish()` is called.
     inner: Option<::fdeflate::Compressor<Vec<u8>>>,
+    /// Holds leftover compressed data after `finish()` that didn't fit in the
+    /// caller's output. Only populated once the compressor is consumed.
+    finished_buf: Vec<u8>,
+    /// Read position within `finished_buf`.
+    finished_pos: usize,
     total_in: u64,
     total_out: u64,
     level: u8,
@@ -189,6 +195,16 @@ impl fmt::Debug for Deflate {
     }
 }
 
+/// Drain as many bytes as possible from `src[*pos..]` into `output`,
+/// returning the number of bytes copied.
+fn drain_to_output(src: &[u8], pos: &mut usize, output: &mut [u8]) -> usize {
+    let available = src.len() - *pos;
+    let copy_len = available.min(output.len());
+    output[..copy_len].copy_from_slice(&src[*pos..*pos + copy_len]);
+    *pos += copy_len;
+    copy_len
+}
+
 impl DeflateBackend for Deflate {
     fn make(level: Compression, zlib_header: bool, _window_bits: u8) -> Self {
         let level_u8 = level.level().min(9) as u8;
@@ -196,8 +212,9 @@ impl DeflateBackend for Deflate {
             ::fdeflate::Compressor::new(Vec::new(), level_u8, zlib_header).unwrap();
 
         Deflate {
-            output_buf: Vec::new(),
             inner: Some(compressor),
+            finished_buf: Vec::new(),
+            finished_pos: 0,
             total_in: 0,
             total_out: 0,
             level: level_u8,
@@ -211,70 +228,73 @@ impl DeflateBackend for Deflate {
         output: &mut [u8],
         flush: FlushCompress,
     ) -> Result<Status, CompressError> {
-        // If we have buffered output from a previous call, drain that first
-        // before processing new input.
-        if !self.output_buf.is_empty() {
-            let copy_len = self.output_buf.len().min(output.len());
-            output[..copy_len].copy_from_slice(&self.output_buf[..copy_len]);
-            self.output_buf.drain(..copy_len);
-            self.total_out += copy_len as u64;
-
-            if !self.output_buf.is_empty() {
-                // Still more buffered output to drain, don't consume any input
-                return Ok(Status::Ok);
-            }
-
-            // If we already finished and the buffer is now drained, we're done.
-            if self.inner.is_none() {
-                return Ok(Status::StreamEnd);
-            }
-
-            // Buffer drained but no new input and not finishing - signal caller
-            if input.is_empty() && flush == FlushCompress::None {
-                return Ok(Status::Ok);
-            }
-        }
-
-        // If the compressor has already been finished and there's nothing
-        // left to drain, signal completion.
+        // After finish(), drain any remaining compressed data.
         if self.inner.is_none() {
+            if self.finished_pos < self.finished_buf.len() {
+                let n = drain_to_output(&self.finished_buf, &mut self.finished_pos, output);
+                self.total_out += n as u64;
+                if self.finished_pos < self.finished_buf.len() {
+                    return Ok(Status::Ok);
+                }
+            }
             return Ok(Status::StreamEnd);
         }
 
-        // Feed input to the compressor
+        let compressor = self.inner.as_mut().unwrap();
+
+        // Drain any compressed data already sitting in the writer from a
+        // previous write_data() call before feeding new input.
+        let mut out_pos = 0;
+        {
+            let writer = compressor.get_writer_mut();
+            let n = drain_to_output(writer, &mut 0, &mut output[out_pos..]);
+            // Remove the drained bytes from the front of the writer Vec.
+            if n > 0 {
+                writer.drain(..n);
+            }
+            self.total_out += n as u64;
+            out_pos += n;
+        }
+
+        // Feed input to the compressor.
         if !input.is_empty() {
-            let compressor = self.inner.as_mut().unwrap();
             if compressor.write_data(input).is_err() {
                 return mem::compress_failed(ErrorMessage);
             }
             self.total_in += input.len() as u64;
+
+            // Drain newly produced compressed data into the remaining output space.
+            let writer = compressor.get_writer_mut();
+            let n = drain_to_output(writer, &mut 0, &mut output[out_pos..]);
+            if n > 0 {
+                writer.drain(..n);
+            }
+            self.total_out += n as u64;
+            out_pos += n;
         }
 
         if flush == FlushCompress::Finish {
-            // Finalize the compressor and collect all remaining output
+            // Finalize the compressor and collect all remaining output.
             let compressor = self.inner.take().unwrap();
             let compressed = match compressor.finish() {
                 Ok(c) => c,
                 Err(_) => return mem::compress_failed(ErrorMessage),
             };
 
-            let copy_len = compressed.len().min(output.len());
-            output[..copy_len].copy_from_slice(&compressed[..copy_len]);
-            self.total_out += copy_len as u64;
+            let n = drain_to_output(&compressed, &mut 0, &mut output[out_pos..]);
+            self.total_out += n as u64;
 
-            if copy_len < compressed.len() {
-                self.output_buf.extend_from_slice(&compressed[copy_len..]);
+            if n < compressed.len() {
+                // Couldn't fit everything — stash the remainder.
+                self.finished_buf = compressed;
+                self.finished_pos = n;
                 return Ok(Status::Ok);
             }
 
             return Ok(Status::StreamEnd);
         }
 
-        // For non-Finish calls: fdeflate buffers compressed data internally in
-        // the Vec<u8> writer. We can't extract partial output without finishing,
-        // so we just report that input was consumed. The compressed output will
-        // become available when finish() is eventually called.
-        if input.is_empty() {
+        if out_pos == 0 && input.is_empty() {
             Ok(Status::BufError)
         } else {
             Ok(Status::Ok)
@@ -284,7 +304,8 @@ impl DeflateBackend for Deflate {
     fn reset(&mut self) {
         self.total_in = 0;
         self.total_out = 0;
-        self.output_buf.clear();
+        self.finished_buf.clear();
+        self.finished_pos = 0;
         self.inner = Some(
             ::fdeflate::Compressor::new(Vec::new(), self.level, self.zlib_header).unwrap(),
         );

--- a/src/ffi/fdeflate.rs
+++ b/src/ffi/fdeflate.rs
@@ -1,0 +1,304 @@
+//! Implementation for `fdeflate` rust backend.
+
+use std::fmt;
+
+use super::*;
+use crate::mem;
+
+// fdeflate doesn't provide error messages
+#[derive(Clone, Default)]
+pub struct ErrorMessage;
+
+impl ErrorMessage {
+    pub fn get(&self) -> Option<&str> {
+        None
+    }
+}
+
+// Constants matching the zlib flush values used by FlushCompress/FlushDecompress.
+// These are defined as isize to match the interface expected by mem.rs for the
+// FlushCompress/FlushDecompress enum discriminants.
+pub const MZ_NO_FLUSH: isize = 0;
+pub const MZ_PARTIAL_FLUSH: isize = 1;
+pub const MZ_SYNC_FLUSH: isize = 2;
+pub const MZ_FULL_FLUSH: isize = 3;
+pub const MZ_FINISH: isize = 4;
+pub const MZ_DEFAULT_WINDOW_BITS: isize = 15;
+
+/// The DEFLATE window size (32 KB). fdeflate's Decompressor uses the output buffer
+/// as a lookback window for back-references, so we must maintain a persistent buffer
+/// that contains at least this much history.
+const WINDOW_SIZE: usize = 32768;
+
+pub struct Inflate {
+    inner: ::fdeflate::Decompressor,
+    /// Persistent output buffer used as the lookback window. fdeflate reads
+    /// back-references from this buffer, so we must keep prior output available.
+    window_buf: Vec<u8>,
+    /// Current write position in `window_buf`.
+    window_pos: usize,
+    total_in: u64,
+    total_out: u64,
+    is_zlib: bool,
+}
+
+impl fmt::Debug for Inflate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "fdeflate inflate internal state. total_in: {}, total_out: {}",
+            self.total_in, self.total_out,
+        )
+    }
+}
+
+impl Inflate {
+    /// Ensure there is room to write `needed` bytes into the window buffer.
+    /// If the buffer is getting too large, shift it to keep only the last WINDOW_SIZE bytes.
+    fn ensure_window_capacity(&mut self, needed: usize) {
+        if self.window_pos + needed > self.window_buf.len() {
+            // Grow the buffer to accommodate the new data
+            self.window_buf.resize(self.window_pos + needed, 0);
+        }
+
+        // Compact when the buffer gets much larger than the window size
+        if self.window_pos > WINDOW_SIZE * 4 {
+            let keep_from = self.window_pos.saturating_sub(WINDOW_SIZE);
+            self.window_buf.copy_within(keep_from..self.window_pos, 0);
+            self.window_pos -= keep_from;
+            self.window_buf.truncate(self.window_pos + needed);
+        }
+    }
+}
+
+impl InflateBackend for Inflate {
+    fn make(zlib_header: bool, _window_bits: u8) -> Self {
+        Inflate {
+            inner: if zlib_header {
+                ::fdeflate::Decompressor::new()
+            } else {
+                ::fdeflate::Decompressor::new_raw()
+            },
+            window_buf: Vec::new(),
+            window_pos: 0,
+            total_in: 0,
+            total_out: 0,
+            is_zlib: zlib_header,
+        }
+    }
+
+    fn decompress(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        _flush: FlushDecompress,
+    ) -> Result<Status, DecompressError> {
+        if self.inner.is_done() {
+            return Ok(Status::StreamEnd);
+        }
+
+        // Make sure we have space in the window buffer for the caller's output size
+        self.ensure_window_capacity(output.len());
+
+        let (consumed, produced) = match self
+            .inner
+            .read(input, &mut self.window_buf, self.window_pos)
+        {
+            Ok(result) => result,
+            Err(_) => return mem::decompress_failed(ErrorMessage),
+        };
+
+        // Copy newly produced bytes to the caller's output buffer
+        output[..produced]
+            .copy_from_slice(&self.window_buf[self.window_pos..self.window_pos + produced]);
+        self.window_pos += produced;
+
+        // When the decompressor finishes, its bit buffer may contain bytes
+        // that were read from input but not actually consumed. Subtract those
+        // so that total_in accurately reflects the compressed stream boundary.
+        let over_read = if self.inner.is_done() {
+            self.inner.unconsumed_bytes()
+        } else {
+            0
+        };
+
+        self.total_in += (consumed - over_read) as u64;
+        self.total_out += produced as u64;
+
+        if self.inner.is_done() {
+            return Ok(Status::StreamEnd);
+        }
+
+        if consumed == 0 && produced == 0 {
+            Ok(Status::BufError)
+        } else {
+            Ok(Status::Ok)
+        }
+    }
+
+    fn reset(&mut self, zlib_header: bool) {
+        self.is_zlib = zlib_header;
+        self.inner = if zlib_header {
+            ::fdeflate::Decompressor::new()
+        } else {
+            ::fdeflate::Decompressor::new_raw()
+        };
+        self.window_buf.clear();
+        self.window_pos = 0;
+        self.total_in = 0;
+        self.total_out = 0;
+    }
+}
+
+impl Backend for Inflate {
+    #[inline]
+    fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    #[inline]
+    fn total_out(&self) -> u64 {
+        self.total_out
+    }
+}
+
+/// Wraps fdeflate's Compressor to implement the streaming DeflateBackend interface.
+///
+/// fdeflate's Compressor takes a `Write` target and has `write_data`/`finish` methods.
+/// We use a `Vec<u8>` as the internal output buffer. Since fdeflate writes compressed
+/// data to the writer during `write_data` and `finish` calls, we buffer that output
+/// and drain it into the caller's output buffer on each `compress` call.
+pub struct Deflate {
+    /// Buffered compressed output that hasn't been returned to the caller yet.
+    output_buf: Vec<u8>,
+    /// The compressor state. Set to `None` after `finish()` is called.
+    inner: Option<::fdeflate::Compressor<Vec<u8>>>,
+    total_in: u64,
+    total_out: u64,
+    level: u8,
+    zlib_header: bool,
+}
+
+impl fmt::Debug for Deflate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "fdeflate deflate internal state. total_in: {}, total_out: {}",
+            self.total_in, self.total_out,
+        )
+    }
+}
+
+impl DeflateBackend for Deflate {
+    fn make(level: Compression, zlib_header: bool, _window_bits: u8) -> Self {
+        let level_u8 = level.level().min(9) as u8;
+        let compressor =
+            ::fdeflate::Compressor::new(Vec::new(), level_u8, zlib_header).unwrap();
+
+        Deflate {
+            output_buf: Vec::new(),
+            inner: Some(compressor),
+            total_in: 0,
+            total_out: 0,
+            level: level_u8,
+            zlib_header,
+        }
+    }
+
+    fn compress(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        flush: FlushCompress,
+    ) -> Result<Status, CompressError> {
+        // If we have buffered output from a previous call, drain that first
+        // before processing new input.
+        if !self.output_buf.is_empty() {
+            let copy_len = self.output_buf.len().min(output.len());
+            output[..copy_len].copy_from_slice(&self.output_buf[..copy_len]);
+            self.output_buf.drain(..copy_len);
+            self.total_out += copy_len as u64;
+
+            if !self.output_buf.is_empty() {
+                // Still more buffered output to drain, don't consume any input
+                return Ok(Status::Ok);
+            }
+
+            // If we already finished and the buffer is now drained, we're done.
+            if self.inner.is_none() {
+                return Ok(Status::StreamEnd);
+            }
+
+            // Buffer drained but no new input and not finishing - signal caller
+            if input.is_empty() && flush == FlushCompress::None {
+                return Ok(Status::Ok);
+            }
+        }
+
+        // If the compressor has already been finished and there's nothing
+        // left to drain, signal completion.
+        if self.inner.is_none() {
+            return Ok(Status::StreamEnd);
+        }
+
+        // Feed input to the compressor
+        if !input.is_empty() {
+            let compressor = self.inner.as_mut().unwrap();
+            if compressor.write_data(input).is_err() {
+                return mem::compress_failed(ErrorMessage);
+            }
+            self.total_in += input.len() as u64;
+        }
+
+        if flush == FlushCompress::Finish {
+            // Finalize the compressor and collect all remaining output
+            let compressor = self.inner.take().unwrap();
+            let compressed = match compressor.finish() {
+                Ok(c) => c,
+                Err(_) => return mem::compress_failed(ErrorMessage),
+            };
+
+            let copy_len = compressed.len().min(output.len());
+            output[..copy_len].copy_from_slice(&compressed[..copy_len]);
+            self.total_out += copy_len as u64;
+
+            if copy_len < compressed.len() {
+                self.output_buf.extend_from_slice(&compressed[copy_len..]);
+                return Ok(Status::Ok);
+            }
+
+            return Ok(Status::StreamEnd);
+        }
+
+        // For non-Finish calls: fdeflate buffers compressed data internally in
+        // the Vec<u8> writer. We can't extract partial output without finishing,
+        // so we just report that input was consumed. The compressed output will
+        // become available when finish() is eventually called.
+        if input.is_empty() {
+            Ok(Status::BufError)
+        } else {
+            Ok(Status::Ok)
+        }
+    }
+
+    fn reset(&mut self) {
+        self.total_in = 0;
+        self.total_out = 0;
+        self.output_buf.clear();
+        self.inner = Some(
+            ::fdeflate::Compressor::new(Vec::new(), self.level, self.zlib_header).unwrap(),
+        );
+    }
+}
+
+impl Backend for Deflate {
+    #[inline]
+    fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    #[inline]
+    fn total_out(&self) -> u64 {
+        self.total_out
+    }
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -77,6 +77,20 @@ mod miniz_oxide;
 #[cfg(all(not(feature = "any_zlib"), feature = "miniz_oxide"))]
 pub use self::miniz_oxide::*;
 
+// Use fdeflate when no other backend is selected.
+#[cfg(all(
+    not(feature = "any_zlib"),
+    not(feature = "miniz_oxide"),
+    feature = "fdeflate"
+))]
+mod fdeflate;
+#[cfg(all(
+    not(feature = "any_zlib"),
+    not(feature = "miniz_oxide"),
+    feature = "fdeflate"
+))]
+pub use self::fdeflate::*;
+
 // If no backend is enabled, fail fast with a clear error message.
 #[cfg(not(feature = "any_impl"))]
 compile_error!("No compression backend selected; enable one of `zlib`, `zlib-ng`, `zlib-rs`, or the default `rust_backend` feature.");

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -113,6 +113,7 @@ pub enum FlushDecompress {
 
 /// The inner state for an error when decompressing
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub(crate) enum DecompressErrorInner {
     General { msg: ErrorMessage },
     NeedsDictionary(u32),
@@ -142,6 +143,7 @@ pub(crate) fn decompress_failed<T>(msg: ErrorMessage) -> Result<T, DecompressErr
 }
 
 #[inline]
+#[allow(dead_code)]
 pub(crate) fn decompress_need_dict<T>(adler: u32) -> Result<T, DecompressError> {
     Err(DecompressError(DecompressErrorInner::NeedsDictionary(
         adler,
@@ -663,6 +665,7 @@ mod tests {
     use crate::write;
     use crate::{Compression, Decompress, FlushDecompress};
 
+    #[cfg(any(feature = "any_zlib", feature = "miniz_oxide"))]
     use crate::{Compress, FlushCompress};
 
     #[test]
@@ -762,6 +765,7 @@ mod tests {
         assert_eq!(err.message(), Some("invalid stored block lengths"));
     }
 
+    #[cfg(any(feature = "any_zlib", feature = "miniz_oxide"))]
     fn compress_with_flush(flush: FlushCompress) -> Vec<u8> {
         let incompressible = (0..=255).collect::<Vec<u8>>();
         let mut output = vec![0; 1024];
@@ -796,6 +800,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "any_zlib", feature = "miniz_oxide"))]
     fn test_partial_flush() {
         let output = compress_with_flush(FlushCompress::Partial);
 
@@ -805,6 +810,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "any_zlib", feature = "miniz_oxide"))]
     fn test_sync_flush() {
         let output = compress_with_flush(FlushCompress::Sync);
 
@@ -813,6 +819,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "any_zlib", feature = "miniz_oxide"))]
     fn test_full_flush() {
         let output = compress_with_flush(FlushCompress::Full);
         assert_eq!(output.len(), 527);


### PR DESCRIPTION
This is a **very early proof-of-concept,** just to get a sense for performance and API gaps. It is mostly vibe-coded and most definitely should not be merged.

Notable findings:

- Some new APIs for private state need to be exposed from `fdeflate`, but nothing too crazy. This branch depends on my fork with the required APIs exposed (jankily).
- The flate2 wrapper needs to maintain an internal window buffer since fdeflate uses the output buffer as a lookback window for back-references, but flate2 passes fresh output slices on each call. This introduces an extra in-memory copy in the inflate path.
- Mid-stream flushing doesn't seem to be supported by `fdeflate`
- Dictionary functionality also seems to be missing

Tests pass, minus the `[0]` input edge case (fails) and mid-stream flushing added in #498 (unsupported?). CI is erroneously green because I didn't add CI jobs for this backend yet.

crc32fast is also not the fastest CRC32 around (see #523) so performance could conceivably be pushed further, either via #523 or by adapting the zlib-rs implementation.

@fintelia FYI