### PR TITLE
Fix infinite loop in writing gzip header/footer

### DIFF
--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -7,6 +7,18 @@ use crate::crc::{Crc, CrcWriter};
 use crate::zio;
 use crate::{Compress, Compression, Decompress, Status};
 
+// Non-gzip writer paths flush through zio::Writer::dump, which converts
+// Ok(0) on a non-empty buffer into WriteZero. Gzip writes its header and footer
+// directly, so keep the same progress rule here.
+fn write_nonzero<W: Write>(writer: &mut W, buf: &[u8]) -> io::Result<usize> {
+    let n = writer.write(buf)?;
+    if n == 0 && !buf.is_empty() {
+        Err(io::ErrorKind::WriteZero.into())
+    } else {
+        Ok(n)
+    }
+}
+
 /// A gzip streaming encoder
 ///
 /// This structure exposes a [`Write`] interface that will emit compressed data
@@ -103,7 +115,7 @@ impl<W: Write> GzEncoder<W> {
                 (amt >> 24) as u8,
             ];
             let inner = self.inner.get_mut();
-            let n = inner.write(&buf[self.crc_bytes_written..])?;
+            let n = write_nonzero(inner, &buf[self.crc_bytes_written..])?;
             self.crc_bytes_written += n;
         }
         Ok(())
@@ -129,7 +141,7 @@ impl<W: Write> GzEncoder<W> {
 
     fn write_header(&mut self) -> io::Result<()> {
         while !self.header.is_empty() {
-            let n = self.inner.get_mut().write(&self.header)?;
+            let n = write_nonzero(self.inner.get_mut(), &self.header)?;
             self.header.drain(..n);
         }
         Ok(())

--- a/tests/zero-write.rs
+++ b/tests/zero-write.rs
@@ -92,6 +92,10 @@ fn gzip_header_zero_write_is_error() {
     // so the loop retried the same write forever. This bounded writer turns
     // that spin into an ordinary error so the test can catch the missing
     // WriteZero handling without hanging.
+    //
+    // Three zero-length writes is arbitrary but enough to show the old code
+    // was retrying instead of treating Ok(0) on a non-empty buffer as
+    // WriteZero.
     let writer = AlwaysZeroThenError::new(3);
     let mut encoder = flate2::write::GzEncoder::new(writer, flate2::Compression::default());
 
@@ -105,6 +109,9 @@ fn gzip_footer_zero_write_is_error() {
     // writer that accepts the header and deflate payload but returns Ok(0) for
     // the empty-stream footer (CRC32 0, ISIZE 0) left crc_bytes_written
     // unchanged, so try_finish retried the same footer slice forever.
+    //
+    // Three zero-length footer writes is arbitrary but enough to show the old
+    // code was retrying the same footer slice instead of returning WriteZero.
     let writer = ZeroOnGzipFooterThenError::new(3);
     let mut encoder = flate2::write::GzEncoder::new(writer, flate2::Compression::default());
 

--- a/tests/zero-write.rs
+++ b/tests/zero-write.rs
@@ -65,7 +65,7 @@ impl Write for ZeroOnGzipFooterThenError {
             return Ok(0);
         }
 
-        if buf.len() == 8 {
+        if buf == [0; 8] {
             self.footer_writes += 1;
             if self.footer_writes > self.max_zero_footer_writes {
                 Err(io::Error::new(
@@ -103,8 +103,8 @@ fn gzip_header_zero_write_is_error() {
 fn gzip_footer_zero_write_is_error() {
     // GzEncoder also used to spin while writing the 8-byte gzip footer. A
     // writer that accepts the header and deflate payload but returns Ok(0) for
-    // the footer left crc_bytes_written unchanged, so try_finish retried the
-    // same footer slice forever.
+    // the empty-stream footer (CRC32 0, ISIZE 0) left crc_bytes_written
+    // unchanged, so try_finish retried the same footer slice forever.
     let writer = ZeroOnGzipFooterThenError::new(3);
     let mut encoder = flate2::write::GzEncoder::new(writer, flate2::Compression::default());
 

--- a/tests/zero-write.rs
+++ b/tests/zero-write.rs
@@ -1,6 +1,113 @@
+use std::io::{self, Write};
+
 #[test]
 fn zero_write_is_error() {
     let mut buf = [0u8];
     let writer = flate2::write::DeflateEncoder::new(&mut buf[..], flate2::Compression::default());
     assert!(writer.finish().is_err());
+}
+
+#[derive(Debug)]
+struct AlwaysZeroThenError {
+    writes: usize,
+    max_zero_writes: usize,
+}
+
+impl AlwaysZeroThenError {
+    fn new(max_zero_writes: usize) -> Self {
+        AlwaysZeroThenError {
+            writes: 0,
+            max_zero_writes,
+        }
+    }
+}
+
+impl Write for AlwaysZeroThenError {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        self.writes += 1;
+        if self.writes > self.max_zero_writes {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "gzip encoder retried a zero-length write",
+            ))
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ZeroOnGzipFooterThenError {
+    footer_writes: usize,
+    max_zero_footer_writes: usize,
+}
+
+impl ZeroOnGzipFooterThenError {
+    fn new(max_zero_footer_writes: usize) -> Self {
+        ZeroOnGzipFooterThenError {
+            footer_writes: 0,
+            max_zero_footer_writes,
+        }
+    }
+}
+
+impl Write for ZeroOnGzipFooterThenError {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        if buf.len() == 8 {
+            self.footer_writes += 1;
+            if self.footer_writes > self.max_zero_footer_writes {
+                Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "gzip encoder retried a zero-length footer write",
+                ))
+            } else {
+                Ok(0)
+            }
+        } else {
+            Ok(buf.len())
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn gzip_header_zero_write_is_error() {
+    // GzEncoder used to spin in write_header when the wrapped writer returned
+    // Ok(0) for the non-empty gzip header buffer: the header was not drained,
+    // so the loop retried the same write forever. This bounded writer turns
+    // that spin into an ordinary error so the test can catch the missing
+    // WriteZero handling without hanging.
+    let writer = AlwaysZeroThenError::new(3);
+    let mut encoder = flate2::write::GzEncoder::new(writer, flate2::Compression::default());
+
+    let err = encoder.try_finish().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::WriteZero);
+}
+
+#[test]
+fn gzip_footer_zero_write_is_error() {
+    // GzEncoder also used to spin while writing the 8-byte gzip footer. A
+    // writer that accepts the header and deflate payload but returns Ok(0) for
+    // the footer left crc_bytes_written unchanged, so try_finish retried the
+    // same footer slice forever.
+    let writer = ZeroOnGzipFooterThenError::new(3);
+    let mut encoder = flate2::write::GzEncoder::new(writer, flate2::Compression::default());
+
+    let err = encoder.try_finish().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::WriteZero);
 }


### PR DESCRIPTION
## Summary

Fix `write::GzEncoder` spinning forever when the wrapped writer returns `Ok(0)` while writing gzip header or footer bytes.

## Problem

Most write paths in flate2 go through `zio::Writer::dump`, which treats `Ok(0)` for a non-empty buffer as `io::ErrorKind::WriteZero`.

`write::GzEncoder` has two gzip-specific direct write loops:
- writing the gzip header
- writing the final 8-byte gzip footer

Those loops previously retried after `Ok(0)` without making progress. A writer that repeatedly returns `Ok(0)` for a non-empty buffer could therefore cause `GzEncoder::try_finish`/`finish`/drop finalization to spin indefinitely.

## Fix

Add a small helper for gzip’s direct writes that mirrors the shared writer behavior: `Ok(0)` on a non-empty buffer is converted to `WriteZero`.

## Tests

Added regression coverage for both spin sites:
- zero-length progress while writing the gzip header
- zero-length progress while writing the gzip footer

Validation:
- `cargo test --test zero-write`
- `cargo test gz::tests`
- `cargo test`

## Credits

The issue was discovered by GPT-5.5 xhigh