### PR TITLE
Add fdeflate backend

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
     - run: cargo test --features zlib-ng --no-default-features
       if: matrix.build != 'mingw'
     - run: cargo test --features zlib-rs --no-default-features
+    - run: cargo test --features fdeflate --no-default-features
     - run: cargo test --features cloudflare_zlib --no-default-features
       if: matrix.build != 'mingw'
     - run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ zlib-rs = { version = "0.6.0", optional = true, default-features = false, featur
 ## This implementation uses only safe Rust code and doesn't require a C compiler.
 ## It provides good performance for most use cases while being completely portable.
 miniz_oxide = { version = "0.9.0", optional = true, features = ["simd"] }
+fdeflate = { git = "https://github.com/Shnatsel/fdeflate.git", branch = "flate2-api-changes", optional = true }
 crc32fast = { version = "1.2.0", optional = true }
 document-features = { version = "0.2", optional = true }
 
@@ -58,6 +59,9 @@ zlib-rs = ["any_zlib", "dep:zlib-rs"] # zlib-rs uses its own crc32 implementatio
 
 ## Use the pure Rust `miniz_oxide` backend.
 miniz_oxide = ["any_impl", "dep:miniz_oxide", "dep:crc32fast"]
+
+## Use the pure Rust `fdeflate` backend.
+fdeflate = ["any_impl", "dep:fdeflate", "dep:crc32fast"]
 
 ## Use the system's installed zlib library.
 ## This is useful when you need compatibility with other C code that uses zlib,

--- a/src/ffi/fdeflate.rs
+++ b/src/ffi/fdeflate.rs
@@ -1,0 +1,387 @@
+//! Implementation for the `fdeflate` Rust backend.
+
+use std::fmt;
+use std::io;
+
+use ::fdeflate::{DecompressionError as FdeflateError, FlushKind};
+
+pub const MZ_NO_FLUSH: isize = 0;
+pub const MZ_PARTIAL_FLUSH: isize = 1;
+pub const MZ_SYNC_FLUSH: isize = 2;
+pub const MZ_FULL_FLUSH: isize = 3;
+pub const MZ_FINISH: isize = 4;
+
+pub const MZ_DEFAULT_WINDOW_BITS: core::ffi::c_int = 15;
+
+use super::*;
+use crate::mem::{compress_failed, decompress_failed};
+
+// fdeflate's decompressor needs one contiguous output slice containing recent history followed by
+// writable space. Keeping 32 KiB of history plus a 64 KiB decode tail avoids copying the history on
+// every call while still bounding how much decoded output we stage ahead of the caller.
+const FDEFLATE_HISTORY_LEN: usize = 32 * 1024;
+const FDEFLATE_DECODE_TAIL_LEN: usize = 64 * 1024;
+const FDEFLATE_SCRATCH_LEN: usize = FDEFLATE_HISTORY_LEN + FDEFLATE_DECODE_TAIL_LEN;
+
+#[derive(Clone, Default)]
+pub struct ErrorMessage(Option<&'static str>);
+
+impl ErrorMessage {
+    pub fn get(&self) -> Option<&str> {
+        self.0
+    }
+}
+
+fn format_from_bool(zlib_header: bool) -> ::fdeflate::Format {
+    if zlib_header {
+        ::fdeflate::Format::Zlib
+    } else {
+        ::fdeflate::Format::Raw
+    }
+}
+
+fn decompression_message(error: FdeflateError) -> &'static str {
+    match error {
+        FdeflateError::BadZlibHeader => "bad zlib header",
+        FdeflateError::InsufficientInput => "insufficient input",
+        FdeflateError::InvalidBlockType => "invalid block type",
+        FdeflateError::InvalidUncompressedBlockLength => "invalid uncompressed block length",
+        FdeflateError::InvalidHlit => "invalid literal/length code count",
+        FdeflateError::InvalidHdist => "invalid distance code count",
+        FdeflateError::InvalidCodeLengthRepeat => "invalid code length repeat",
+        FdeflateError::BadCodeLengthHuffmanTree => "bad code length huffman tree",
+        FdeflateError::BadLiteralLengthHuffmanTree => "bad literal/length huffman tree",
+        FdeflateError::BadDistanceHuffmanTree => "bad distance huffman tree",
+        FdeflateError::InvalidLiteralLengthCode => "invalid literal/length code",
+        FdeflateError::InvalidDistanceCode => "invalid distance code",
+        FdeflateError::InputStartsWithRun => "input starts with a run",
+        FdeflateError::DistanceTooFarBack => "distance too far back",
+        FdeflateError::WrongChecksum => "wrong checksum",
+        FdeflateError::ExtraInput => "extra input",
+    }
+}
+
+fn io_error_message(_: io::Error) -> ErrorMessage {
+    ErrorMessage(Some("fdeflate compression failed"))
+}
+
+fn compression_result<T>(result: io::Result<T>) -> Result<T, CompressError> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) => compress_failed(io_error_message(error)),
+    }
+}
+
+fn new_compressor(level: u8, zlib_header: bool) -> ::fdeflate::Compressor<Vec<u8>> {
+    ::fdeflate::Compressor::new(Vec::new(), level, zlib_header)
+        .expect("writing fdeflate output to a Vec cannot fail")
+}
+
+fn drain_vec(pending: &mut Vec<u8>, pending_pos: &mut usize, output: &mut [u8]) -> usize {
+    let n = (pending.len() - *pending_pos).min(output.len());
+    output[..n].copy_from_slice(&pending[*pending_pos..*pending_pos + n]);
+    *pending_pos += n;
+    if *pending_pos == pending.len() {
+        pending.clear();
+        *pending_pos = 0;
+    }
+    n
+}
+
+pub struct Deflate {
+    inner: Option<::fdeflate::Compressor<Vec<u8>>>,
+    pending: Vec<u8>,
+    pending_pos: usize,
+    inner_pending_pos: usize,
+    level: u8,
+    zlib_header: bool,
+    total_in: u64,
+    total_out: u64,
+}
+
+impl fmt::Debug for Deflate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "fdeflate deflate internal state. total_in: {}, total_out: {}",
+            self.total_in, self.total_out,
+        )
+    }
+}
+
+impl Deflate {
+    fn drain_pending(&mut self, output: &mut [u8]) -> usize {
+        let mut output_index = drain_vec(&mut self.pending, &mut self.pending_pos, output);
+
+        if output_index < output.len() {
+            if let Some(ref mut inner) = self.inner {
+                // fdeflate writes into the wrapped Vec; flate2 callers own the real destination, so
+                // drain those pending bytes before accepting more input. Track a cursor instead of
+                // draining the Vec so small caller buffers do not force repeated memmoves.
+                output_index += drain_vec(
+                    inner.get_mut(),
+                    &mut self.inner_pending_pos,
+                    &mut output[output_index..],
+                );
+            }
+        }
+
+        self.total_out += output_index as u64;
+        output_index
+    }
+
+    fn is_finished(&self) -> bool {
+        self.inner.is_none() && self.pending.is_empty()
+    }
+}
+
+impl DeflateBackend for Deflate {
+    fn make(level: Compression, zlib_header: bool, _window_bits: u8) -> Self {
+        let level = level.level().min(9) as u8;
+        Deflate {
+            inner: Some(new_compressor(level, zlib_header)),
+            pending: Vec::new(),
+            pending_pos: 0,
+            inner_pending_pos: 0,
+            level,
+            zlib_header,
+            total_in: 0,
+            total_out: 0,
+        }
+    }
+
+    fn compress(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        flush: FlushCompress,
+    ) -> Result<Status, CompressError> {
+        let before_in = self.total_in;
+        let before_out = self.total_out;
+
+        let output_index = self.drain_pending(output);
+        if output_index == output.len() {
+            return if self.is_finished() {
+                Ok(Status::StreamEnd)
+            } else if output.is_empty() {
+                Ok(Status::BufError)
+            } else {
+                Ok(Status::Ok)
+            };
+        }
+
+        if self.inner.is_none() {
+            return Ok(Status::StreamEnd);
+        }
+
+        if let Some(ref mut inner) = self.inner {
+            if !input.is_empty() {
+                compression_result(inner.write_data(input))?;
+                self.total_in += input.len() as u64;
+            }
+
+            match flush {
+                FlushCompress::None => {}
+                FlushCompress::Partial => compression_result(inner.flush(FlushKind::Partial))?,
+                FlushCompress::Sync => compression_result(inner.flush(FlushKind::Sync))?,
+                FlushCompress::Full => compression_result(inner.flush(FlushKind::Full))?,
+                FlushCompress::Finish => {
+                    let inner = self.inner.take().unwrap();
+                    self.pending = compression_result(inner.finish())?;
+                    self.pending_pos = 0;
+                    self.inner_pending_pos = 0;
+                }
+            }
+        }
+
+        self.drain_pending(&mut output[output_index..]);
+
+        if self.is_finished() {
+            Ok(Status::StreamEnd)
+        } else if before_in == self.total_in && before_out == self.total_out {
+            Ok(Status::BufError)
+        } else {
+            Ok(Status::Ok)
+        }
+    }
+
+    fn reset(&mut self) {
+        self.inner = Some(new_compressor(self.level, self.zlib_header));
+        self.pending.clear();
+        self.pending_pos = 0;
+        self.inner_pending_pos = 0;
+        self.total_in = 0;
+        self.total_out = 0;
+    }
+}
+
+impl Backend for Deflate {
+    #[inline]
+    fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    #[inline]
+    fn total_out(&self) -> u64 {
+        self.total_out
+    }
+}
+
+pub struct Inflate {
+    inner: ::fdeflate::Decompressor,
+    scratch: Vec<u8>,
+    drain_pos: usize,
+    decode_pos: usize,
+    total_in: u64,
+    total_out: u64,
+    done: bool,
+}
+
+impl fmt::Debug for Inflate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "fdeflate inflate internal state. total_in: {}, total_out: {}",
+            self.total_in, self.total_out,
+        )
+    }
+}
+
+impl Inflate {
+    fn has_pending_output(&self) -> bool {
+        self.drain_pos < self.decode_pos
+    }
+
+    fn drain_output(&mut self, output: &mut [u8]) -> usize {
+        let n = (self.decode_pos - self.drain_pos).min(output.len());
+        output[..n].copy_from_slice(&self.scratch[self.drain_pos..self.drain_pos + n]);
+        self.drain_pos += n;
+        self.total_out += n as u64;
+        n
+    }
+
+    fn compact_if_needed(&mut self) {
+        debug_assert!(!self.has_pending_output());
+
+        if self.decode_pos + FDEFLATE_DECODE_TAIL_LEN <= self.scratch.len() {
+            return;
+        }
+
+        // A VecDeque would avoid this occasional copy, but fdeflate needs a single contiguous
+        // slice containing both lookback history and writable output. Once the staged output has
+        // been drained, keep only the 32 KiB deflate history and reopen the 64 KiB decode tail.
+        let keep = self.decode_pos.min(FDEFLATE_HISTORY_LEN);
+        let start = self.decode_pos - keep;
+        if start != 0 {
+            self.scratch.copy_within(start..self.decode_pos, 0);
+        }
+        self.drain_pos = keep;
+        self.decode_pos = keep;
+    }
+}
+
+impl InflateBackend for Inflate {
+    fn make(zlib_header: bool, _window_bits: u8) -> Self {
+        let format = format_from_bool(zlib_header);
+        Inflate {
+            inner: ::fdeflate::Decompressor::new_with_format(format),
+            scratch: vec![0; FDEFLATE_SCRATCH_LEN],
+            drain_pos: 0,
+            decode_pos: 0,
+            total_in: 0,
+            total_out: 0,
+            done: false,
+        }
+    }
+
+    fn decompress(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        _flush: FlushDecompress,
+    ) -> Result<Status, DecompressError> {
+        let before_in = self.total_in;
+        let before_out = self.total_out;
+
+        // Always drain staged output first. This keeps the scratch buffer from accumulating more
+        // than the tunable 64 KiB decode tail when callers provide very small output buffers.
+        let output_index = self.drain_output(output);
+        if output_index == output.len() {
+            return if self.done && !self.has_pending_output() {
+                Ok(Status::StreamEnd)
+            } else if output.is_empty() {
+                Ok(Status::BufError)
+            } else {
+                Ok(Status::Ok)
+            };
+        }
+
+        if self.done {
+            return Ok(Status::StreamEnd);
+        }
+
+        self.compact_if_needed();
+
+        let mut input_index = 0;
+        loop {
+            let target_end = (self.decode_pos + FDEFLATE_DECODE_TAIL_LEN).min(self.scratch.len());
+            if self.decode_pos == target_end {
+                break;
+            }
+
+            let (consumed, produced) = match self.inner.read(
+                &input[input_index..],
+                &mut self.scratch[..target_end],
+                self.decode_pos,
+            ) {
+                Ok(result) => result,
+                Err(error) => {
+                    return decompress_failed(ErrorMessage(Some(decompression_message(error))));
+                }
+            };
+            input_index += consumed;
+            self.total_in += consumed as u64;
+            self.decode_pos += produced;
+            self.done = self.inner.is_done();
+
+            // fdeflate may need one more turn after producing output to consume the final EOF
+            // marker from its bit buffer. Keep decoding into the contiguous tail until there is
+            // no internal progress left, the stream ends, or the staging tail is full.
+            if self.done || (consumed == 0 && produced == 0) {
+                break;
+            }
+        }
+
+        self.drain_output(&mut output[output_index..]);
+
+        if self.done && !self.has_pending_output() {
+            Ok(Status::StreamEnd)
+        } else if before_in == self.total_in && before_out == self.total_out {
+            Ok(Status::BufError)
+        } else {
+            Ok(Status::Ok)
+        }
+    }
+
+    fn reset(&mut self, zlib_header: bool) {
+        let format = format_from_bool(zlib_header);
+        self.inner.reset(format);
+        self.drain_pos = 0;
+        self.decode_pos = 0;
+        self.total_in = 0;
+        self.total_out = 0;
+        self.done = false;
+    }
+}
+
+impl Backend for Inflate {
+    #[inline]
+    fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    #[inline]
+    fn total_out(&self) -> u64 {
+        self.total_out
+    }
+}

--- a/src/ffi/fdeflate.rs
+++ b/src/ffi/fdeflate.rs
@@ -23,6 +23,11 @@ const FDEFLATE_HISTORY_LEN: usize = 32 * 1024;
 const FDEFLATE_DECODE_TAIL_LEN: usize = 64 * 1024;
 const FDEFLATE_SCRATCH_LEN: usize = FDEFLATE_HISTORY_LEN + FDEFLATE_DECODE_TAIL_LEN;
 
+// fdeflate compresses into its wrapped writer, not directly into flate2's caller-provided output
+// slice. Capping fresh input per call keeps that wrapped Vec from growing with arbitrarily large
+// caller slices while still amortizing fdeflate's block/parser overhead.
+const FDEFLATE_ENCODE_INPUT_CHUNK_LEN: usize = 128 * 1024;
+
 #[derive(Clone, Default)]
 pub struct ErrorMessage(Option<&'static str>);
 
@@ -174,22 +179,31 @@ impl DeflateBackend for Deflate {
             return Ok(Status::StreamEnd);
         }
 
+        let accepted_input_len = input.len().min(FDEFLATE_ENCODE_INPUT_CHUNK_LEN);
+        let accepted_all_input = accepted_input_len == input.len();
+
         if let Some(ref mut inner) = self.inner {
-            if !input.is_empty() {
-                compression_result(inner.write_data(input))?;
-                self.total_in += input.len() as u64;
+            if accepted_input_len != 0 {
+                let accepted_input = &input[..accepted_input_len];
+                compression_result(inner.write_data(accepted_input))?;
+                self.total_in += accepted_input.len() as u64;
             }
 
-            match flush {
-                FlushCompress::None => {}
-                FlushCompress::Partial => compression_result(inner.flush(FlushKind::Partial))?,
-                FlushCompress::Sync => compression_result(inner.flush(FlushKind::Sync))?,
-                FlushCompress::Full => compression_result(inner.flush(FlushKind::Full))?,
-                FlushCompress::Finish => {
-                    let inner = self.inner.take().unwrap();
-                    self.pending = compression_result(inner.finish())?;
-                    self.pending_pos = 0;
-                    self.inner_pending_pos = 0;
+            // A flush describes all input provided to this call. If we only accepted a prefix to
+            // preserve streaming backpressure, defer the flush until the caller comes back with the
+            // remaining input, just like other backends report partial consumption through total_in.
+            if accepted_all_input {
+                match flush {
+                    FlushCompress::None => {}
+                    FlushCompress::Partial => compression_result(inner.flush(FlushKind::Partial))?,
+                    FlushCompress::Sync => compression_result(inner.flush(FlushKind::Sync))?,
+                    FlushCompress::Full => compression_result(inner.flush(FlushKind::Full))?,
+                    FlushCompress::Finish => {
+                        let inner = self.inner.take().unwrap();
+                        self.pending = compression_result(inner.finish())?;
+                        self.pending_pos = 0;
+                        self.inner_pending_pos = 0;
+                    }
                 }
             }
         }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -71,10 +71,24 @@ mod zlib_rs;
 #[cfg(all(not(feature = "any_c_zlib"), feature = "zlib-rs"))]
 pub use self::zlib_rs::*;
 
+// Use fdeflate when no fully compliant zlib is selected and fdeflate is explicitly requested.
+#[cfg(all(not(feature = "any_zlib"), feature = "fdeflate"))]
+mod fdeflate;
+#[cfg(all(not(feature = "any_zlib"), feature = "fdeflate"))]
+pub use self::fdeflate::*;
+
 // Use miniz_oxide when no fully compliant zlib is selected.
-#[cfg(all(not(feature = "any_zlib"), feature = "miniz_oxide"))]
+#[cfg(all(
+    not(feature = "any_zlib"),
+    not(feature = "fdeflate"),
+    feature = "miniz_oxide"
+))]
 mod miniz_oxide;
-#[cfg(all(not(feature = "any_zlib"), feature = "miniz_oxide"))]
+#[cfg(all(
+    not(feature = "any_zlib"),
+    not(feature = "fdeflate"),
+    feature = "miniz_oxide"
+))]
 pub use self::miniz_oxide::*;
 
 // If no backend is enabled, fail fast with a clear error message.

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -114,7 +114,10 @@ pub enum FlushDecompress {
 /// The inner state for an error when decompressing
 #[derive(Clone, Debug)]
 pub(crate) enum DecompressErrorInner {
-    General { msg: ErrorMessage },
+    General {
+        msg: ErrorMessage,
+    },
+    #[allow(dead_code)]
     NeedsDictionary(u32),
 }
 
@@ -142,6 +145,7 @@ pub(crate) fn decompress_failed<T>(msg: ErrorMessage) -> Result<T, DecompressErr
 }
 
 #[inline]
+#[allow(dead_code)]
 pub(crate) fn decompress_need_dict<T>(adler: u32) -> Result<T, DecompressError> {
     Err(DecompressError(DecompressErrorInner::NeedsDictionary(
         adler,
@@ -663,6 +667,7 @@ mod tests {
     use crate::write;
     use crate::{Compression, Decompress, FlushDecompress};
 
+    #[cfg(not(feature = "fdeflate"))]
     use crate::{Compress, FlushCompress};
 
     #[test]
@@ -762,6 +767,9 @@ mod tests {
         assert_eq!(err.message(), Some("invalid stored block lengths"));
     }
 
+    // TODO: Re-enable these flush byte-layout tests for fdeflate once
+    // https://github.com/image-rs/fdeflate/pull/73 is available in the dependency.
+    #[cfg(not(feature = "fdeflate"))]
     fn compress_with_flush(flush: FlushCompress) -> Vec<u8> {
         let incompressible = (0..=255).collect::<Vec<u8>>();
         let mut output = vec![0; 1024];
@@ -795,6 +803,7 @@ mod tests {
         output
     }
 
+    #[cfg(not(feature = "fdeflate"))]
     #[test]
     fn test_partial_flush() {
         let output = compress_with_flush(FlushCompress::Partial);
@@ -804,6 +813,7 @@ mod tests {
         assert_eq!(output[262] & 0x7, 0x4);
     }
 
+    #[cfg(not(feature = "fdeflate"))]
     #[test]
     fn test_sync_flush() {
         let output = compress_with_flush(FlushCompress::Sync);
@@ -812,6 +822,7 @@ mod tests {
         assert_eq!(&output[261..][..5], &[0, 0, 0, 0xff, 0xff]);
     }
 
+    #[cfg(not(feature = "fdeflate"))]
     #[test]
     fn test_full_flush() {
         let output = compress_with_flush(FlushCompress::Full);

--- a/tests/fdeflate.rs
+++ b/tests/fdeflate.rs
@@ -76,6 +76,27 @@ fn raw_trailing_bytes_remain_unconsumed() {
 }
 
 #[test]
+fn large_no_flush_call_preserves_streaming_backpressure() {
+    let input = vec![0x5a; 2 * 1024 * 1024];
+    let mut output = [0; 1];
+    let mut encoder = Compress::new(Compression::default(), false);
+
+    let status = encoder
+        .compress(&input, &mut output, FlushCompress::None)
+        .unwrap();
+
+    assert_eq!(status, Status::Ok);
+    assert!(
+        encoder.total_in() > 0,
+        "the compressor should still accept some input"
+    );
+    assert!(
+        encoder.total_in() < input.len() as u64,
+        "fdeflate should return to the caller before buffering the whole input"
+    );
+}
+
+#[test]
 fn zlib_trailing_bytes_remain_unconsumed() {
     let input = b"zlib stream with extra data after it";
     let mut encoded = Vec::with_capacity(1024);

--- a/tests/fdeflate.rs
+++ b/tests/fdeflate.rs
@@ -1,0 +1,150 @@
+#![cfg(feature = "fdeflate")]
+
+use flate2::{Compress, Compression, Decompress, FlushCompress, FlushDecompress, Status};
+use std::io::{Read, Write};
+
+fn compress_raw(input: &[u8]) -> Vec<u8> {
+    let mut encoded = Vec::with_capacity(input.len() + 1024);
+    let mut encoder = Compress::new(Compression::default(), false);
+    let status = encoder
+        .compress_vec(input, &mut encoded, FlushCompress::Finish)
+        .unwrap();
+    assert_eq!(status, Status::StreamEnd);
+    encoded
+}
+
+fn decompress_raw(encoded: &[u8], expected_len: usize) -> Vec<u8> {
+    let mut decoder = Decompress::new(false);
+    let mut decoded = vec![0; expected_len];
+    let status = decoder
+        .decompress(encoded, &mut decoded, FlushDecompress::Finish)
+        .unwrap();
+    assert_eq!(status, Status::StreamEnd);
+    decoded.truncate(decoder.total_out() as usize);
+    decoded
+}
+
+#[test]
+fn raw_roundtrip_with_one_byte_output() {
+    let input = vec![b'a'; 128 * 1024];
+    let encoded = compress_raw(&input);
+    let mut decoder = Decompress::new(false);
+    let mut decoded = Vec::with_capacity(input.len());
+    let mut input_pos = 0;
+
+    loop {
+        let before_in = decoder.total_in();
+        let before_out = decoder.total_out();
+        let mut byte = [0; 1];
+        let status = decoder
+            .decompress(&encoded[input_pos..], &mut byte, FlushDecompress::None)
+            .unwrap();
+        input_pos += (decoder.total_in() - before_in) as usize;
+        let written = (decoder.total_out() - before_out) as usize;
+        decoded.extend_from_slice(&byte[..written]);
+
+        if status == Status::StreamEnd {
+            break;
+        }
+
+        assert!(
+            written != 0 || decoder.total_in() != before_in,
+            "decoder made no progress"
+        );
+    }
+
+    assert_eq!(decoded, input);
+    assert_eq!(input_pos, encoded.len());
+}
+
+#[test]
+fn raw_trailing_bytes_remain_unconsumed() {
+    let input = b"raw stream with extra data after it";
+    let encoded = compress_raw(input);
+    let mut with_trailing = encoded.clone();
+    with_trailing.extend_from_slice(b"extra");
+
+    let mut decoder = Decompress::new(false);
+    let mut decoded = vec![0; 1024];
+    let status = decoder
+        .decompress(&with_trailing, &mut decoded, FlushDecompress::Finish)
+        .unwrap();
+
+    assert_eq!(status, Status::StreamEnd);
+    assert_eq!(decoder.total_in(), encoded.len() as u64);
+    assert_eq!(&decoded[..decoder.total_out() as usize], input);
+}
+
+#[test]
+fn zlib_trailing_bytes_remain_unconsumed() {
+    let input = b"zlib stream with extra data after it";
+    let mut encoded = Vec::with_capacity(1024);
+    let mut encoder = Compress::new(Compression::default(), true);
+    assert_eq!(
+        encoder
+            .compress_vec(input, &mut encoded, FlushCompress::Finish)
+            .unwrap(),
+        Status::StreamEnd
+    );
+    let compressed_len = encoded.len();
+    encoded.extend_from_slice(b"extra");
+
+    let mut decoder = Decompress::new(true);
+    let mut decoded = vec![0; 1024];
+    let status = decoder
+        .decompress(&encoded, &mut decoded, FlushDecompress::Finish)
+        .unwrap();
+
+    assert_eq!(status, Status::StreamEnd);
+    assert_eq!(decoder.total_in(), compressed_len as u64);
+    assert_eq!(&decoded[..decoder.total_out() as usize], input);
+}
+
+#[test]
+fn partial_sync_and_full_flush_roundtrip() {
+    for flush in [
+        FlushCompress::Partial,
+        FlushCompress::Sync,
+        FlushCompress::Full,
+    ] {
+        let first = b"first half first half first half";
+        let second = b"second half second half second half";
+        let mut encoded = Vec::with_capacity(4096);
+        let mut encoder = Compress::new(Compression::default(), false);
+        encoder.compress_vec(first, &mut encoded, flush).unwrap();
+        assert_eq!(
+            encoder
+                .compress_vec(second, &mut encoded, FlushCompress::Finish)
+                .unwrap(),
+            Status::StreamEnd
+        );
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(first);
+        expected.extend_from_slice(second);
+        assert_eq!(decompress_raw(&encoded, expected.len()), expected);
+    }
+}
+
+#[test]
+fn read_and_write_wrappers_roundtrip_single_zero() {
+    let input = [0];
+    let direct_encoded = compress_raw(&input);
+    assert_eq!(decompress_raw(&direct_encoded, input.len()), input);
+
+    let mut encoder = flate2::read::DeflateEncoder::new(&input[..], Compression::default());
+    let mut encoded = Vec::new();
+    encoder.read_to_end(&mut encoded).unwrap();
+
+    let mut reader = flate2::read::DeflateDecoder::new(&encoded[..]);
+    let mut decoded = Vec::new();
+    reader.read_to_end(&mut decoded).unwrap();
+    assert_eq!(decoded, input);
+
+    let mut writer = flate2::write::DeflateEncoder::new(
+        flate2::write::DeflateDecoder::new(Vec::new()),
+        Compression::default(),
+    );
+    writer.write_all(&input).unwrap();
+    assert_eq!(writer.finish().unwrap().finish().unwrap(), input);
+}


### PR DESCRIPTION
Add support for using [fdeflate](https://crates.io/crates/fdeflate) as a compression/decompression backend. It's already proven in the `png` crate used by Chromium (among other things).

The backend priority is above miniz_oxide but below zlib and zlib-rs.

This PR is basically #545 but with more effort put into it.

It still depends on two upstream PRs, so I'm marking this a draft:

 - https://github.com/image-rs/fdeflate/pull/81 for the necessary API additions
 - https://github.com/image-rs/fdeflate/pull/73 to remove fdeflate exceptions from the flush tests and help compression ratio a bit (flushing already works, but tests expect stored/fixed blocks which aren't yet merged upstream)

Buffer sizes are a guess for now, and will need tuning. Larger sizes will likely improve performance by reducing the frequency of copying the lookback buffer, at the cost of higher memory use. These will need to be adjusted to be in line with the other backends for the total amount of memory consumed.

@fintelia FYI