### PR TITLE
Reject oversized gzip extra fields

### DIFF
--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::ffi::CString;
 use std::io::{BufRead, Error, ErrorKind, Read, Result, Write};
 use std::time;
@@ -411,7 +412,12 @@ impl GzBuilder {
         let mut header = vec![0u8; 10];
         if let Some(v) = extra {
             flg |= FEXTRA;
-            header.extend((v.len() as u16).to_le_bytes());
+            header.extend(
+                (u16::try_from(v.len()).expect(
+                    "`extra` can only be created from `extra()` which would have panicked on len > u16::MAX",
+                ))
+                .to_le_bytes(),
+            );
             header.extend(v);
         }
         if let Some(filename) = filename {

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -338,8 +338,17 @@ impl GzBuilder {
     }
 
     /// Configure the `extra` field in the gzip header.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `extra` is longer than [`u16::MAX`].
     pub fn extra<T: Into<Vec<u8>>>(mut self, extra: T) -> GzBuilder {
-        self.extra = Some(extra.into());
+        let extra = extra.into();
+        assert!(
+            extra.len() <= u16::MAX as usize,
+            "gzip extra field length cannot exceed u16::MAX"
+        );
+        self.extra = Some(extra);
         self
     }
 
@@ -746,6 +755,12 @@ mod tests {
         let mut res = Vec::new();
         d.read_to_end(&mut res).unwrap();
         assert_eq!(res, vec![0, 2, 4, 6]);
+    }
+
+    #[test]
+    #[should_panic(expected = "gzip extra field length cannot exceed u16::MAX")]
+    fn extra_too_long() {
+        GzBuilder::new().extra(vec![0; u16::MAX as usize + 1]);
     }
 
     #[test]

--- a/src/zio.rs
+++ b/src/zio.rs
@@ -185,7 +185,7 @@ impl<W: Write, D: Ops> Writer<W, D> {
     }
 
     pub fn replace(&mut self, w: W) -> W {
-        self.buf.truncate(0);
+        self.buf.clear();
         mem::replace(self.get_mut(), w)
     }
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #552

## Summary

Reject gzip extra fields larger than `u16::MAX` when they are supplied to `GzBuilder::extra`. This prevents XLEN from wrapping while the full extra field is serialized and matches the documented eager panic behavior of the filename and comment setters.

## Validation

- `cargo fmt -- --check`
- `cargo test gz::tests::extra_too_long`
- `cargo test gz::tests::fields`
- `cargo test --lib` (62 passed)

Codex commit review found no issues. Its additional `cargo test --all-features` attempt could not download `libz-ng-sys` because DNS resolution for crates.io failed.
