### PR TITLE
Reject incomplete deflate streams at EOF

### DIFF
--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -166,7 +166,9 @@ mod tests {
     fn rejects_incomplete_stream() {
         for input in [b"1".as_slice(), b"12", b"123", b"1234"] {
             let mut decoder = read::DeflateDecoder::new(input);
-            assert!(std::io::copy(&mut decoder, &mut std::io::sink()).is_err());
+            let error = std::io::copy(&mut decoder, &mut std::io::sink()).unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+            assert_eq!(error.to_string(), "incomplete deflate stream");
         }
     }
 

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -163,6 +163,14 @@ mod tests {
     }
 
     #[test]
+    fn rejects_incomplete_stream() {
+        for input in [b"1".as_slice(), b"12", b"123", b"1234"] {
+            let mut decoder = read::DeflateDecoder::new(input);
+            assert!(std::io::copy(&mut decoder, &mut std::io::sink()).is_err());
+        }
+    }
+
+    #[test]
     fn qc_reader() {
         ::quickcheck::quickcheck(test as fn(_) -> _);
 

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -738,6 +738,17 @@ mod tests {
     }
 
     #[test]
+    fn read_decoder_rejects_incomplete_deflate_stream() {
+        let mut compressed = gzip_corrupted_crc();
+        compressed.truncate(11);
+        let error = read::GzDecoder::new(&compressed[..])
+            .read_to_end(&mut Vec::new())
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+        assert_eq!(error.to_string(), "incomplete deflate stream");
+    }
+
+    #[test]
     fn write_decoder_detects_corrupted_crc() {
         let compressed = gzip_corrupted_crc();
         let mut decoder = write::GzDecoder::new(Vec::new());

--- a/src/zio.rs
+++ b/src/zio.rs
@@ -149,6 +149,12 @@ where
             // return that 0 bytes of data have been read then it will
             // be interpreted as EOF.
             Ok(Status::Ok | Status::BufError) if read == 0 && !eof && !dst.is_empty() => continue,
+            Ok(Status::Ok | Status::BufError) if read == 0 && eof && !dst.is_empty() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "incomplete deflate stream",
+                ));
+            }
             Ok(Status::Ok | Status::BufError | Status::StreamEnd) => return Ok(read),
 
             Err(..) => {

--- a/src/zio.rs
+++ b/src/zio.rs
@@ -144,11 +144,13 @@ where
         obj.consume(consumed);
 
         match ret {
-            // If we haven't ready any data and we haven't hit EOF yet,
+            // If we haven't read any data and we haven't hit EOF yet,
             // then we need to keep asking for more data because if we
             // return that 0 bytes of data have been read then it will
             // be interpreted as EOF.
             Ok(Status::Ok | Status::BufError) if read == 0 && !eof && !dst.is_empty() => continue,
+            // If we haven't read any data and we have hit EOF, then the
+            // deflate stream is incomplete.
             Ok(Status::Ok | Status::BufError) if read == 0 && eof && !dst.is_empty() => {
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,

--- a/src/zlib/mod.rs
+++ b/src/zlib/mod.rs
@@ -131,6 +131,20 @@ mod tests {
     }
 
     #[test]
+    fn rejects_incomplete_stream() {
+        let mut encoder = write::ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(b"hello").unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        for end in compressed.len() - 4..compressed.len() {
+            let mut decoder = read::ZlibDecoder::new(&compressed[..end]);
+            let error = std::io::copy(&mut decoder, &mut std::io::sink()).unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+            assert_eq!(error.to_string(), "incomplete deflate stream");
+        }
+    }
+
+    #[test]
     fn qc_reader() {
         ::quickcheck::quickcheck(test as fn(_) -> _);
 


### PR DESCRIPTION
Read decoders could return EOF successfully when the input ended before the deflate stream reached StreamEnd.

Treat a no-progress Ok or BufError at input EOF as UnexpectedEof, and cover the short invalid inputs from #499 across the read decoder.

Fixes #499