### PR TITLE
Update `get_mut()` documentation to make clear how 'inner` can be used

### DIFF
--- a/src/deflate/bufread.rs
+++ b/src/deflate/bufread.rs
@@ -78,8 +78,11 @@ impl<R> DeflateEncoder<R> {
 
     /// Acquires a mutable reference to the underlying stream
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this encoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this encoder.
+    ///
+    /// To process a new stream, wait for this encoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.obj
     }
@@ -208,8 +211,11 @@ impl<R> DeflateDecoder<R> {
 
     /// Acquires a mutable reference to the underlying stream
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this decoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this decoder.
+    ///
+    /// To process a new stream, wait for this decoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.obj
     }

--- a/src/deflate/read.rs
+++ b/src/deflate/read.rs
@@ -70,8 +70,11 @@ impl<R> DeflateEncoder<R> {
 
     /// Acquires a mutable reference to the underlying stream
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this encoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this encoder.
+    ///
+    /// To process a new stream, wait for this encoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         self.inner.get_mut().get_mut()
     }
@@ -201,8 +204,11 @@ impl<R> DeflateDecoder<R> {
 
     /// Acquires a mutable reference to the underlying stream
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this decoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this decoder.
+    ///
+    /// To process a new stream, wait for this decoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         self.inner.get_mut().get_mut()
     }

--- a/src/deflate/write.rs
+++ b/src/deflate/write.rs
@@ -52,11 +52,13 @@ impl<W: Write> DeflateEncoder<W> {
     ///
     /// The underlying writer may be mutated or replaced as long as this
     /// preserves the bytes and ordering of the logical output stream.
+    /// Concatenate output from each writer to reconstruct the complete stream.
     ///
-    /// For streaming output, call [`flush`](Write::flush) before replacing the
-    /// writer, such as with [`std::mem::take`], to retrieve all output produced
-    /// so far. Concatenate output from each writer to reconstruct the complete
-    /// stream.
+    /// Replacing the writer does not require [`flush`](Write::flush). Call it
+    /// first when all input accepted so far must be decodable without output
+    /// from later writes. This inserts a sync-flush point and changes the output
+    /// bitstream. This is useful before applying [`std::mem::take`] to
+    /// [`get_mut`](Self::get_mut) when forwarding the stream incrementally.
     ///
     /// To start a new stream, use [`reset`](Self::reset); replacing the writer
     /// does not reset this encoder.
@@ -237,11 +239,12 @@ impl<W: Write> DeflateDecoder<W> {
     ///
     /// The underlying writer may be mutated or replaced as long as this
     /// preserves the bytes and ordering of the logical output stream.
+    /// Concatenate output from each writer to reconstruct the complete stream.
     ///
-    /// For streaming output, call [`flush`](Write::flush) before replacing the
-    /// writer, such as with [`std::mem::take`], to retrieve all output produced
-    /// so far. Concatenate output from each writer to reconstruct the complete
-    /// stream.
+    /// Replacing the writer does not require [`flush`](Write::flush). Call it
+    /// first to write all decompressed output currently available to the
+    /// current writer. This is useful before applying [`std::mem::take`] to
+    /// [`get_mut`](Self::get_mut) when forwarding output incrementally.
     ///
     /// To start a new stream, use [`reset`](Self::reset); replacing the writer
     /// does not reset this decoder.

--- a/src/deflate/write.rs
+++ b/src/deflate/write.rs
@@ -50,8 +50,16 @@ impl<W: Write> DeflateEncoder<W> {
 
     /// Acquires a mutable reference to the underlying writer.
     ///
-    /// Note that mutating the output/input state of the stream may corrupt this
-    /// object, so care must be taken when using this method.
+    /// The underlying writer may be mutated or replaced as long as this
+    /// preserves the bytes and ordering of the logical output stream.
+    ///
+    /// For streaming output, call [`flush`](Write::flush) before replacing the
+    /// writer, such as with [`std::mem::take`], to retrieve all output produced
+    /// so far. Concatenate output from each writer to reconstruct the complete
+    /// stream.
+    ///
+    /// To start a new stream, use [`reset`](Self::reset); replacing the writer
+    /// does not reset this encoder.
     pub fn get_mut(&mut self) -> &mut W {
         self.inner.get_mut()
     }
@@ -227,8 +235,16 @@ impl<W: Write> DeflateDecoder<W> {
 
     /// Acquires a mutable reference to the underlying writer.
     ///
-    /// Note that mutating the output/input state of the stream may corrupt this
-    /// object, so care must be taken when using this method.
+    /// The underlying writer may be mutated or replaced as long as this
+    /// preserves the bytes and ordering of the logical output stream.
+    ///
+    /// For streaming output, call [`flush`](Write::flush) before replacing the
+    /// writer, such as with [`std::mem::take`], to retrieve all output produced
+    /// so far. Concatenate output from each writer to reconstruct the complete
+    /// stream.
+    ///
+    /// To start a new stream, use [`reset`](Self::reset); replacing the writer
+    /// does not reset this decoder.
     pub fn get_mut(&mut self) -> &mut W {
         self.inner.get_mut()
     }

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -103,8 +103,11 @@ impl<R> GzEncoder<R> {
 
     /// Acquires a mutable reference to the underlying reader.
     ///
-    /// Note that mutation of the reader may result in surprising results if
-    /// this encoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this encoder.
+    ///
+    /// To process a new stream, wait for this encoder to reach EOF and create a
+    /// new encoder; replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         self.inner.get_mut().get_mut()
     }
@@ -272,8 +275,11 @@ impl<R> GzDecoder<R> {
 
     /// Acquires a mutable reference to the underlying stream.
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this decoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this decoder.
+    ///
+    /// To process a new stream, wait for this decoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         self.reader.get_mut().get_mut()
     }
@@ -434,8 +440,11 @@ impl<R> MultiGzDecoder<R> {
 
     /// Acquires a mutable reference to the underlying stream.
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this decoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this decoder.
+    ///
+    /// To process a new stream, wait for this decoder to reach EOF and create a
+    /// new decoder; replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         self.0.get_mut()
     }

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -61,8 +61,11 @@ impl<R> GzEncoder<R> {
 
     /// Acquires a mutable reference to the underlying reader.
     ///
-    /// Note that mutation of the reader may result in surprising results if
-    /// this encoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this encoder.
+    ///
+    /// To process a new stream, wait for this encoder to reach EOF and create a
+    /// new encoder; replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         self.inner.get_mut().get_mut()
     }
@@ -163,8 +166,11 @@ impl<R> GzDecoder<R> {
 
     /// Acquires a mutable reference to the underlying stream.
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this decoder continues to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this decoder.
+    ///
+    /// To process a new stream, wait for this decoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     ///
     /// Note that the decoder may have read past the end of the gzip data.
     /// To prevent this use [`bufread::GzDecoder`] instead.
@@ -283,8 +289,11 @@ impl<R> MultiGzDecoder<R> {
 
     /// Acquires a mutable reference to the underlying stream.
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this decoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this decoder.
+    ///
+    /// To process a new stream, wait for this decoder to reach EOF and create a
+    /// new decoder; replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         self.inner.get_mut().get_mut()
     }

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -77,8 +77,16 @@ impl<W: Write> GzEncoder<W> {
 
     /// Acquires a mutable reference to the underlying writer.
     ///
-    /// Note that mutation of the writer may result in surprising results if
-    /// this encoder is continued to be used.
+    /// The underlying writer may be mutated or replaced as long as this
+    /// preserves the bytes and ordering of the logical output stream.
+    ///
+    /// For streaming output, call [`flush`](Write::flush) before replacing the
+    /// writer, such as with [`std::mem::take`], to retrieve all output produced
+    /// so far. Concatenate output from each writer to reconstruct the complete
+    /// stream.
+    ///
+    /// To start a new stream, call [`finish`](Self::finish) and create a new
+    /// encoder; replacing the writer does not reset it.
     pub fn get_mut(&mut self) -> &mut W {
         self.inner.get_mut()
     }
@@ -253,8 +261,16 @@ impl<W: Write> GzDecoder<W> {
 
     /// Acquires a mutable reference to the underlying writer.
     ///
-    /// Note that mutating the output/input state of the stream may corrupt this
-    /// object, so care must be taken when using this method.
+    /// The underlying writer may be mutated or replaced as long as this
+    /// preserves the bytes and ordering of the logical output stream.
+    ///
+    /// For streaming output, call [`flush`](Write::flush) before replacing the
+    /// writer, such as with [`std::mem::take`], to retrieve all output produced
+    /// so far. Concatenate output from each writer to reconstruct the complete
+    /// stream.
+    ///
+    /// To start a new stream, call [`finish`](Self::finish) and create a new
+    /// decoder; replacing the writer does not reset it.
     pub fn get_mut(&mut self) -> &mut W {
         self.inner.get_mut().get_mut()
     }
@@ -407,8 +423,16 @@ impl<W: Write> MultiGzDecoder<W> {
 
     /// Acquires a mutable reference to the underlying writer.
     ///
-    /// Note that mutating the output/input state of the stream may corrupt this
-    /// object, so care must be taken when using this method.
+    /// The underlying writer may be mutated or replaced as long as this
+    /// preserves the bytes and ordering of the logical output stream.
+    ///
+    /// For streaming output, call [`flush`](Write::flush) before replacing the
+    /// writer, such as with [`std::mem::take`], to retrieve all output produced
+    /// so far. Concatenate output from each writer to reconstruct the complete
+    /// stream.
+    ///
+    /// To start a new stream, call [`finish`](Self::finish) and create a new
+    /// decoder; replacing the writer does not reset it.
     pub fn get_mut(&mut self) -> &mut W {
         self.inner.get_mut()
     }

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -79,11 +79,13 @@ impl<W: Write> GzEncoder<W> {
     ///
     /// The underlying writer may be mutated or replaced as long as this
     /// preserves the bytes and ordering of the logical output stream.
+    /// Concatenate output from each writer to reconstruct the complete stream.
     ///
-    /// For streaming output, call [`flush`](Write::flush) before replacing the
-    /// writer, such as with [`std::mem::take`], to retrieve all output produced
-    /// so far. Concatenate output from each writer to reconstruct the complete
-    /// stream.
+    /// Replacing the writer does not require [`flush`](Write::flush). Call it
+    /// first when all input accepted so far must be decodable without output
+    /// from later writes. This inserts a sync-flush point and changes the output
+    /// bitstream. This is useful before applying [`std::mem::take`] to
+    /// [`get_mut`](Self::get_mut) when forwarding the stream incrementally.
     ///
     /// To start a new stream, call [`finish`](Self::finish) and create a new
     /// encoder; replacing the writer does not reset it.
@@ -263,11 +265,12 @@ impl<W: Write> GzDecoder<W> {
     ///
     /// The underlying writer may be mutated or replaced as long as this
     /// preserves the bytes and ordering of the logical output stream.
+    /// Concatenate output from each writer to reconstruct the complete stream.
     ///
-    /// For streaming output, call [`flush`](Write::flush) before replacing the
-    /// writer, such as with [`std::mem::take`], to retrieve all output produced
-    /// so far. Concatenate output from each writer to reconstruct the complete
-    /// stream.
+    /// Replacing the writer does not require [`flush`](Write::flush). Call it
+    /// first to write all decompressed output currently available to the
+    /// current writer. This is useful before applying [`std::mem::take`] to
+    /// [`get_mut`](Self::get_mut) when forwarding output incrementally.
     ///
     /// To start a new stream, call [`finish`](Self::finish) and create a new
     /// decoder; replacing the writer does not reset it.
@@ -425,11 +428,12 @@ impl<W: Write> MultiGzDecoder<W> {
     ///
     /// The underlying writer may be mutated or replaced as long as this
     /// preserves the bytes and ordering of the logical output stream.
+    /// Concatenate output from each writer to reconstruct the complete stream.
     ///
-    /// For streaming output, call [`flush`](Write::flush) before replacing the
-    /// writer, such as with [`std::mem::take`], to retrieve all output produced
-    /// so far. Concatenate output from each writer to reconstruct the complete
-    /// stream.
+    /// Replacing the writer does not require [`flush`](Write::flush). Call it
+    /// first to write all decompressed output currently available to the
+    /// current writer. This is useful before applying [`std::mem::take`] to
+    /// [`get_mut`](Self::get_mut) when forwarding output incrementally.
     ///
     /// To start a new stream, call [`finish`](Self::finish) and create a new
     /// decoder; replacing the writer does not reset it.

--- a/src/zlib/bufread.rs
+++ b/src/zlib/bufread.rs
@@ -83,8 +83,11 @@ impl<R> ZlibEncoder<R> {
 
     /// Acquires a mutable reference to the underlying stream
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this encoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this encoder.
+    ///
+    /// To process a new stream, wait for this encoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.obj
     }
@@ -216,8 +219,11 @@ impl<R> ZlibDecoder<R> {
 
     /// Acquires a mutable reference to the underlying stream
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this decoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this decoder.
+    ///
+    /// To process a new stream, wait for this decoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.obj
     }

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -76,8 +76,11 @@ impl<R> ZlibEncoder<R> {
 
     /// Acquires a mutable reference to the underlying stream
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this encoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this encoder.
+    ///
+    /// To process a new stream, wait for this encoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         self.inner.get_mut().get_mut()
     }
@@ -235,8 +238,11 @@ impl<R> ZlibDecoder<R> {
 
     /// Acquires a mutable reference to the underlying stream
     ///
-    /// Note that mutation of the stream may result in surprising results if
-    /// this decoder is continued to be used.
+    /// The underlying reader may be mutated as long as its unread input and
+    /// current position are preserved for subsequent reads by this decoder.
+    ///
+    /// To process a new stream, wait for this decoder to reach EOF and use
+    /// [`reset`](Self::reset); replacing the reader directly does not reset it.
     pub fn get_mut(&mut self) -> &mut R {
         self.inner.get_mut().get_mut()
     }

--- a/src/zlib/write.rs
+++ b/src/zlib/write.rs
@@ -59,8 +59,16 @@ impl<W: Write> ZlibEncoder<W> {
 
     /// Acquires a mutable reference to the underlying writer.
     ///
-    /// Note that mutating the output/input state of the stream may corrupt this
-    /// object, so care must be taken when using this method.
+    /// The underlying writer may be mutated or replaced as long as this
+    /// preserves the bytes and ordering of the logical output stream.
+    ///
+    /// For streaming output, call [`flush`](Write::flush) before replacing the
+    /// writer, such as with [`std::mem::take`], to retrieve all output produced
+    /// so far. Concatenate output from each writer to reconstruct the complete
+    /// stream.
+    ///
+    /// To start a new stream, use [`reset`](Self::reset); replacing the writer
+    /// does not reset this encoder.
     pub fn get_mut(&mut self) -> &mut W {
         self.inner.get_mut()
     }
@@ -248,8 +256,16 @@ impl<W: Write> ZlibDecoder<W> {
 
     /// Acquires a mutable reference to the underlying writer.
     ///
-    /// Note that mutating the output/input state of the stream may corrupt this
-    /// object, so care must be taken when using this method.
+    /// The underlying writer may be mutated or replaced as long as this
+    /// preserves the bytes and ordering of the logical output stream.
+    ///
+    /// For streaming output, call [`flush`](Write::flush) before replacing the
+    /// writer, such as with [`std::mem::take`], to retrieve all output produced
+    /// so far. Concatenate output from each writer to reconstruct the complete
+    /// stream.
+    ///
+    /// To start a new stream, use [`reset`](Self::reset); replacing the writer
+    /// does not reset this decoder.
     pub fn get_mut(&mut self) -> &mut W {
         self.inner.get_mut()
     }

--- a/src/zlib/write.rs
+++ b/src/zlib/write.rs
@@ -61,11 +61,13 @@ impl<W: Write> ZlibEncoder<W> {
     ///
     /// The underlying writer may be mutated or replaced as long as this
     /// preserves the bytes and ordering of the logical output stream.
+    /// Concatenate output from each writer to reconstruct the complete stream.
     ///
-    /// For streaming output, call [`flush`](Write::flush) before replacing the
-    /// writer, such as with [`std::mem::take`], to retrieve all output produced
-    /// so far. Concatenate output from each writer to reconstruct the complete
-    /// stream.
+    /// Replacing the writer does not require [`flush`](Write::flush). Call it
+    /// first when all input accepted so far must be decodable without output
+    /// from later writes. This inserts a sync-flush point and changes the output
+    /// bitstream. This is useful before applying [`std::mem::take`] to
+    /// [`get_mut`](Self::get_mut) when forwarding the stream incrementally.
     ///
     /// To start a new stream, use [`reset`](Self::reset); replacing the writer
     /// does not reset this encoder.
@@ -258,11 +260,12 @@ impl<W: Write> ZlibDecoder<W> {
     ///
     /// The underlying writer may be mutated or replaced as long as this
     /// preserves the bytes and ordering of the logical output stream.
+    /// Concatenate output from each writer to reconstruct the complete stream.
     ///
-    /// For streaming output, call [`flush`](Write::flush) before replacing the
-    /// writer, such as with [`std::mem::take`], to retrieve all output produced
-    /// so far. Concatenate output from each writer to reconstruct the complete
-    /// stream.
+    /// Replacing the writer does not require [`flush`](Write::flush). Call it
+    /// first to write all decompressed output currently available to the
+    /// current writer. This is useful before applying [`std::mem::take`] to
+    /// [`get_mut`](Self::get_mut) when forwarding output incrementally.
     ///
     /// To start a new stream, use [`reset`](Self::reset); replacing the writer
     /// does not reset this decoder.


### PR DESCRIPTION
This should help steering towards `reset()` in places where `flush() + swap(get_mut, x)` might otherwise be used.

It also mentions how to use `get_mut()` for streaming.

Fixes #555
