### PR TITLE
Include `README.md` in a private module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,6 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - run: cargo build
-    - run: rustdoc --test README.md -L target/debug/deps --extern flate2=target/debug/libflate2.rlib --edition=2018
     - run: cargo test
     - run: cargo test --features zlib
     - run: cargo test --features zlib --no-default-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,3 +258,7 @@ fn random_bytes() -> impl Iterator<Item = u8> {
 
     iter::repeat(()).map(|_| rand::rng().random())
 }
+
+#[allow(rustdoc::bare_urls)]
+#[doc = include_str!("../README.md")]
+mod readme {}


### PR DESCRIPTION
# Description

- Fixes #561

## Solution

- Include `README.md` on a private `readme` module to ensure doc tests are run as a normal part of `cargo test`.
- Remove explicit `rustdoc` step in the `test` CI job.

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.